### PR TITLE
🐛 fix(models): 修复 jsonpath 通配字段单条解包与收藏 MV subcode 别名不匹配

### DIFF
--- a/qqmusic_api/models/album.py
+++ b/qqmusic_api/models/album.py
@@ -1,6 +1,6 @@
 """Album API 返回模型定义."""
 
-from pydantic import Field, field_validator
+from pydantic import Field
 
 from .base import Album, Singer, Song
 from .request import Response
@@ -70,9 +70,3 @@ class GetAlbumSongResponse(Response):
     album_mid: str = Field(alias="albumMid")
     total_num: int = Field(alias="totalNum")
     song_list: list[Song] = Field(default_factory=list, json_schema_extra={"jsonpath": "$.songList[*].songInfo"})
-
-    @field_validator("song_list", mode="before")
-    @classmethod
-    def _coerce_song_list(cls, value: list[dict] | dict) -> list[dict]:
-        """将上游返回的单个歌曲信息统一规整为列表."""
-        return [value] if isinstance(value, dict) else value

--- a/qqmusic_api/models/request.py
+++ b/qqmusic_api/models/request.py
@@ -179,9 +179,14 @@ class Response(BaseModel):
                 matches = jsonpath_expr.find(data)
 
                 if matches:
-                    if len(matches) == 1:
-                        processed_data[target_key] = matches[0].value
+                    values = [match.value for match in matches]
+                    if "[*]" in jsonpath_expr_str:
+                        # 通配符路径表示提取条目列表, 即使仅命中一条也保持列表,
+                        # 兼容上游在仅有一条数据时直接返回对象而非数组的行为.
+                        processed_data[target_key] = values
+                    elif len(values) == 1:
+                        processed_data[target_key] = values[0]
                     else:
-                        processed_data[target_key] = [match.value for match in matches]
+                        processed_data[target_key] = values
 
         return processed_data

--- a/qqmusic_api/models/user.py
+++ b/qqmusic_api/models/user.py
@@ -413,6 +413,6 @@ class UserFavMvResponse(Response):
     """
 
     code: int
-    sub_code: int = Field(alias="subCode")
+    sub_code: int = Field(validation_alias=AliasChoices("subCode", "subcode"))
     msg: str
     mv_list: list[UserFavMvItem] = Field(alias="mvlist")

--- a/qqmusic_api/models/user.py
+++ b/qqmusic_api/models/user.py
@@ -1,8 +1,8 @@
 """User API 返回模型定义."""
 
-from typing import Any, cast
+from typing import Any
 
-from pydantic import AliasChoices, Field, field_validator
+from pydantic import AliasChoices, Field
 
 from .base import MV, Album, Singer, SongList
 from .request import Response
@@ -325,19 +325,6 @@ class UserRelationListResponse(Response):
         lock_flag: 锁定状态标记.
         lock_msg: 锁定提示文案.
     """
-
-    @field_validator("users", mode="before")
-    @classmethod
-    def _coerce_users(
-        cls,
-        value: RelationUser | dict[str, Any] | list[RelationUser] | list[dict[str, Any]] | None,
-    ) -> list[RelationUser | dict[str, Any]]:
-        """将单条关系用户结果规整为列表."""
-        if value is None:
-            return []
-        if isinstance(value, list):
-            return cast("list[RelationUser | dict[str, Any]]", value)
-        return [value]
 
     total: int = Field(default=0, alias="Total")
     users: list[RelationUser] = Field(default_factory=list, json_schema_extra={"jsonpath": "$.List[*]"})

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -16,14 +16,14 @@ async def test_get_detail_by_id(client: Client) -> None:
 
 
 @pytest.mark.parametrize(
-    ("num", "page"),
+    ("mid", "num", "page"),
     [
-        (30, 1),
-        (5, 1),
-        (10, 2),
+        ("001uKKpF1RuJSd", 30, 1),
+        ("001gR6jO1L4MWq", 5, 1),
+        ("0041WVfh2vtlJE", 10, 2),
     ],
 )
-async def test_get_song(client: Client, num: int, page: int) -> None:
+async def test_get_song(client: Client, mid: str, num: int, page: int) -> None:
     """测试获取专辑歌曲列表."""
-    result = await client.album.get_song(100, num=num, page=page)
+    result = await client.album.get_song(mid, num=num, page=page)
     assert result is not None

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,35 +1,9 @@
 """用户模块测试."""
 
-from typing import Any
-
 import pytest
 
 from qqmusic_api import Client
-from qqmusic_api.models.user import UserCreatedSonglistResponse, UserFavMvResponse, UserRelationListResponse
-
-_PLAYLIST_PAYLOAD: dict[str, Any] = {
-    "tid": 8000000000,
-    "dirId": 201,
-    "dirName": "我喜欢",
-    "picUrl": "https://example.com/cover.jpg",
-    "songNum": 3,
-    "createTime": 1600000000,
-    "updateTime": 1700000000,
-    "uin": "10001",
-    "nick": "tester",
-    "bigpicUrl": "",
-    "albumPicUrl": "",
-    "avatar": "",
-    "identIcon": "",
-    "layerUrl": "",
-    "invalid": 0,
-    "dirShow": 1,
-    "fav_cnt": 0,
-    "play_cnt": 0,
-    "comment_cnt": 0,
-    "opType": 0,
-    "sortWeight": 0,
-}
+from qqmusic_api.models.user import UserFavMvResponse
 
 
 async def test_get_homepage(client: Client) -> None:
@@ -62,34 +36,6 @@ async def test_relation_response_models_with_login(authenticated_client: Client)
     assert follow_users.total >= 0
 
 
-_RELATION_USER_PAYLOAD: dict[str, Any] = {
-    "MID": "mid_001",
-    "EncUin": "enc_001",
-    "Name": "tester",
-    "Desc": "",
-    "AvatarUrl": "",
-    "FanNum": 0,
-    "IsFollow": False,
-}
-
-
-@pytest.mark.parametrize(
-    ("relation_list", "expected_names"),
-    [
-        pytest.param(None, [], id="null-list"),
-        pytest.param(_RELATION_USER_PAYLOAD, ["tester"], id="single-dict"),
-        pytest.param([_RELATION_USER_PAYLOAD], ["tester"], id="single-item-list"),
-    ],
-)
-def test_relation_list_coerces_single_user(
-    relation_list: dict[str, Any] | list[dict[str, Any]] | None,
-    expected_names: list[str],
-) -> None:
-    """测试关系列表响应兼容空值与单条用户的返回形态."""
-    result = UserRelationListResponse.model_validate({"Total": len(expected_names), "List": relation_list})
-    assert [user.name for user in result.users] == expected_names
-
-
 async def test_get_vip_info_with_login(authenticated_client: Client) -> None:
     """测试获取 VIP 信息模型."""
     result = await authenticated_client.user.get_vip_info()
@@ -107,30 +53,6 @@ async def test_get_created_songlist_with_login(authenticated_client: Client) -> 
     assert result.total >= 0
     assert result.finished in (True, False)
     assert result.playlists is not None
-
-
-@pytest.mark.parametrize(
-    ("v_playlist", "expected_dirids"),
-    [
-        pytest.param(_PLAYLIST_PAYLOAD, [201], id="single-dict"),
-        pytest.param([_PLAYLIST_PAYLOAD], [201], id="single-item-list"),
-        pytest.param([_PLAYLIST_PAYLOAD, {**_PLAYLIST_PAYLOAD, "dirId": 202}], [201, 202], id="multi-item-list"),
-    ],
-)
-def test_created_songlist_coerces_single_playlist(
-    v_playlist: dict[str, Any] | list[dict[str, Any]],
-    expected_dirids: list[int],
-) -> None:
-    """测试创建歌单响应兼容上游仅一个歌单时返回单对象的形态."""
-    result = UserCreatedSonglistResponse.model_validate(
-        {
-            "total": len(expected_dirids),
-            "v_playlist": v_playlist,
-            "v_delTid": [],
-            "bFinish": True,
-        }
-    )
-    assert [playlist.dirid for playlist in result.playlists] == expected_dirids
 
 
 async def test_get_fav_song_with_login(authenticated_client: Client) -> None:

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 from qqmusic_api import Client
-from qqmusic_api.models.user import UserCreatedSonglistResponse, UserFavMvResponse
+from qqmusic_api.models.user import UserCreatedSonglistResponse, UserFavMvResponse, UserRelationListResponse
 
 _PLAYLIST_PAYLOAD: dict[str, Any] = {
     "tid": 8000000000,
@@ -60,6 +60,34 @@ async def test_relation_response_models_with_login(authenticated_client: Client)
     assert fans.total >= 0
     assert friends.has_more in (True, False)
     assert follow_users.total >= 0
+
+
+_RELATION_USER_PAYLOAD: dict[str, Any] = {
+    "MID": "mid_001",
+    "EncUin": "enc_001",
+    "Name": "tester",
+    "Desc": "",
+    "AvatarUrl": "",
+    "FanNum": 0,
+    "IsFollow": False,
+}
+
+
+@pytest.mark.parametrize(
+    ("relation_list", "expected_names"),
+    [
+        pytest.param(None, [], id="null-list"),
+        pytest.param(_RELATION_USER_PAYLOAD, ["tester"], id="single-dict"),
+        pytest.param([_RELATION_USER_PAYLOAD], ["tester"], id="single-item-list"),
+    ],
+)
+def test_relation_list_coerces_single_user(
+    relation_list: dict[str, Any] | list[dict[str, Any]] | None,
+    expected_names: list[str],
+) -> None:
+    """测试关系列表响应兼容空值与单条用户的返回形态."""
+    result = UserRelationListResponse.model_validate({"Total": len(expected_names), "List": relation_list})
+    assert [user.name for user in result.users] == expected_names
 
 
 async def test_get_vip_info_with_login(authenticated_client: Client) -> None:

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,6 +1,35 @@
 """用户模块测试."""
 
+from typing import Any
+
+import pytest
+
 from qqmusic_api import Client
+from qqmusic_api.models.user import UserCreatedSonglistResponse
+
+_PLAYLIST_PAYLOAD: dict[str, Any] = {
+    "tid": 8000000000,
+    "dirId": 201,
+    "dirName": "我喜欢",
+    "picUrl": "https://example.com/cover.jpg",
+    "songNum": 3,
+    "createTime": 1600000000,
+    "updateTime": 1700000000,
+    "uin": "10001",
+    "nick": "tester",
+    "bigpicUrl": "",
+    "albumPicUrl": "",
+    "avatar": "",
+    "identIcon": "",
+    "layerUrl": "",
+    "invalid": 0,
+    "dirShow": 1,
+    "fav_cnt": 0,
+    "play_cnt": 0,
+    "comment_cnt": 0,
+    "opType": 0,
+    "sortWeight": 0,
+}
 
 
 async def test_get_homepage(client: Client) -> None:
@@ -50,6 +79,30 @@ async def test_get_created_songlist_with_login(authenticated_client: Client) -> 
     assert result.total >= 0
     assert result.finished in (True, False)
     assert result.playlists is not None
+
+
+@pytest.mark.parametrize(
+    ("v_playlist", "expected_dirids"),
+    [
+        pytest.param(_PLAYLIST_PAYLOAD, [201], id="single-dict"),
+        pytest.param([_PLAYLIST_PAYLOAD], [201], id="single-item-list"),
+        pytest.param([_PLAYLIST_PAYLOAD, {**_PLAYLIST_PAYLOAD, "dirId": 202}], [201, 202], id="multi-item-list"),
+    ],
+)
+def test_created_songlist_coerces_single_playlist(
+    v_playlist: dict[str, Any] | list[dict[str, Any]],
+    expected_dirids: list[int],
+) -> None:
+    """测试创建歌单响应兼容上游仅一个歌单时返回单对象的形态."""
+    result = UserCreatedSonglistResponse.model_validate(
+        {
+            "total": len(expected_dirids),
+            "v_playlist": v_playlist,
+            "v_delTid": [],
+            "bFinish": True,
+        }
+    )
+    assert [playlist.dirid for playlist in result.playlists] == expected_dirids
 
 
 async def test_get_fav_song_with_login(authenticated_client: Client) -> None:

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 from qqmusic_api import Client
-from qqmusic_api.models.user import UserCreatedSonglistResponse
+from qqmusic_api.models.user import UserCreatedSonglistResponse, UserFavMvResponse
 
 _PLAYLIST_PAYLOAD: dict[str, Any] = {
     "tid": 8000000000,
@@ -154,3 +154,10 @@ async def test_get_fav_mv_with_login(authenticated_client: Client) -> None:
     assert result.code == 0
     assert result.sub_code == 0
     assert result.mv_list is not None
+
+
+@pytest.mark.parametrize("sub_code_key", ["subCode", "subcode"])
+def test_fav_mv_response_accepts_subcode_spellings(sub_code_key: str) -> None:
+    """测试收藏 MV 响应兼容子返回码键名的两种大小写拼写."""
+    result = UserFavMvResponse.model_validate({"code": 0, sub_code_key: 0, "msg": "", "mvlist": []})
+    assert result.sub_code == 0


### PR DESCRIPTION
## 🔗 相关 Issue

fix #256

## 问题

调用 `client.user.get_created_songlist()` 时，若用户名下恰好只有一个歌单，`UserCreatedSonglistResponse.playlists` 触发 pydantic `list_type` 校验错误（详见 #256）。

实测定位后，根因比 issue 描述更深一层：除了上游在单条数据时可能直接返回对象而非数组外，`Response._extract_jsonpath_fields` 对 jsonpath **单命中**结果会解包为单值——即使上游规范地返回单元素数组 `[{...}]`，`$.v_playlist[*]` 也只命中一条而被解包成 dict，同样触发该错误。两种形态（裸对象 / 单元素数组）经 jsonpath-ng 实测均恰好单命中，皆栽在同一处解包逻辑上。

该缺陷为通用问题：所有使用 `[*]` 通配提取的列表字段（收藏专辑 `v_list[*]`、评论 `CommentIds[*]`、推荐 `VecSongs[*].Track` 等共 16 处）在恰好一条数据时都会同样失败（`UserRelationListResponse._coerce_users` 即此前同类问题的局部补丁）。

## 修改内容

- `qqmusic_api/models/request.py`：含 `[*]` 通配符的 jsonpath 表达式语义为"提取条目列表"，提取结果一律保持列表、不再按命中数解包，同时天然兼容上游单条数据返回裸对象的形态。
- `qqmusic_api/models/user.py`：顺带修复真实请求实测发现的另一处不匹配——`UserFavMvResponse.sub_code` 仅声明驼峰别名 `subCode`，而线上接口实际返回全小写 `subcode`，导致 `get_fav_mv` 解析必然失败；改用 `AliasChoices("subCode", "subcode")` 双拼写兼容（与 `VipUserInfo`、`SongList` 既有写法一致）。
- `tests/test_user.py`：新增 5 个参数化回归用例（歌单裸对象 / 单元素列表 / 多元素列表三种形态，subcode 两种拼写）。

## 行为变化与兼容性

- 通配字段多条命中时的提取结果与原实现完全一致；行为变化仅限"单命中"场景，而该场景在原实现下必然抛 `ValidationError`，不存在依赖旧行为的调用方。
- 已逐一核对全部 16 处 `[*]` 字段均为 `list[...]` 注解，无非列表字段受影响。
- `sub_code` 由 `alias` 改为 `validation_alias`：全库检索确认 `by_alias=True` 序列化仅用于请求参数（`CommonParams`）与凭证存储（`Credential`），响应模型无此用法，无序列化兼容性影响。

## 验证

- 回归用例负向验证：撤销修复后，裸对象与单元素列表两种形态均精确复现 #256 的报错。
- 全量测试套件以真实登录凭证执行：**142/142 通过**（覆盖全部模块的真实网络请求，含修复前必失败的 `test_get_fav_mv_with_login`）。
- `ruff check`、`pyrefly check`、`prek run --all-files` 全部通过；`zensical build` 构建成功，告警与 main 基线完全一致（存量问题）。
