### PR TITLE
✨ feat(user): 新增收藏/取消收藏歌单 API

### DIFF
--- a/qqmusic_api/modules/user.py
+++ b/qqmusic_api/modules/user.py
@@ -288,6 +288,46 @@ class UserApi(ApiModule):
             ),
         )
 
+    async def fav_songlist(self, songlist_id: int, *, credential: Credential | None = None) -> bool:
+        """收藏歌单 (将他人的公开歌单加入当前账号的收藏).
+
+        Args:
+            songlist_id: 歌单 ID, 即歌单的 disstid/pid (不是自建歌单的 dirid).
+            credential: 登录凭证.
+
+        Returns:
+            是否收藏成功 (歌单已在收藏中也返回 True).
+        """
+        target_credential = self._require_login(credential)
+        data = await self._build_request(
+            module="music.musicasset.PlaylistFavWrite",
+            method="FavPlaylist",
+            param={"uin": target_credential.encrypt_uin, "v_playlistId": [songlist_id]},
+            credential=target_credential,
+            require_login=True,
+        )
+        return data.get("result") == 0 and songlist_id not in (data.get("v_failedPlaylistId") or [])
+
+    async def unfav_songlist(self, songlist_id: int, *, credential: Credential | None = None) -> bool:
+        """取消收藏歌单.
+
+        Args:
+            songlist_id: 歌单 ID, 即歌单的 disstid/pid (不是自建歌单的 dirid).
+            credential: 登录凭证.
+
+        Returns:
+            是否取消成功 (歌单本就不在收藏中也返回 True).
+        """
+        target_credential = self._require_login(credential)
+        data = await self._build_request(
+            module="music.musicasset.PlaylistFavWrite",
+            method="CancelFavPlaylist",
+            param={"uin": target_credential.encrypt_uin, "v_playlistId": [songlist_id]},
+            credential=target_credential,
+            require_login=True,
+        )
+        return data.get("result") == 0 and songlist_id not in (data.get("v_failedPlaylistId") or [])
+
     def get_fav_album(
         self,
         euin: str,

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -122,6 +122,13 @@ def test_fav_mv_response_accepts_subcode_spellings(sub_code_key: str) -> None:
     assert result.sub_code == 0
 
 
+async def test_fav_songlist_with_login(authenticated_client: Client) -> None:
+    """测试收藏和取消收藏歌单 (自收自取, 不残留账号状态)."""
+    songlist_id = 9578424174
+    assert await authenticated_client.user.fav_songlist(songlist_id) is True
+    assert await authenticated_client.user.unfav_songlist(songlist_id) is True
+
+
 async def test_dislike_song_with_login(authenticated_client: Client) -> None:
     """测试不喜欢和取消不喜欢歌曲."""
     song_id = 398282803


### PR DESCRIPTION
## 🔗 相关 Issue

补齐"收藏 / 取消收藏外部歌单"的写接口 —— 目前库只有 `user.get_fav_songlist`(`PlaylistFavRead`) 读接口，没有对应的写接口。

## 改动

新增 `UserApi.fav_songlist` / `UserApi.unfav_songlist`，与已有的 `get_fav_songlist` 同 namespace：

| 项 | 值 |
|----|----|
| module | `music.musicasset.PlaylistFavWrite` |
| 收藏 method | `FavPlaylist` |
| 取消 method | `CancelFavPlaylist` |
| param | `{"uin": <encrypt_uin>, "v_playlistId": [<歌单 disstid/pid, int>]}` |
| 成功判定 | `result == 0` 且目标 id 不在 `v_failedPlaylistId` 中 |

实现要点（实测踩过的坑）：

- `uin` 必须用 `credential.encrypt_uin`（形如 `owCF...**`），用 `str(musicid)` 会返 `no valid playlist`。
- `v_playlistId` 传的是**歌单 disstid/pid**（别人的公开歌单），**不是自建歌单的 dirid**（201="我喜欢"）。
- 成功看 **`result`** 字段（`=0` 成功），不是其它写接口常见的 `retCode`。
- 被证伪的候选：`method=FavPlaylist` + `param={v_tid, opertype}`（opertype 1/2 区分收藏/取消）在本账号/端点返 `no valid playlist`，故采用按 method 名区分（`FavPlaylist` / `CancelFavPlaylist`）。

## 测试

新增 `test_fav_songlist_with_login`：对一个公开歌单**自收自取**，不残留账号状态（与 `test_dislike_song_with_login` 同风格）。

真机验证（通过本库自身的请求层，非旁路）：

```
pre-state: PID 9578424174 已收藏 = False
fav_songlist   -> True; 回读出现 = True
unfav_songlist -> True; 回读消失 = True
账号状态完全复原
```

本地检查全绿：`ruff check` / `ruff format --check` / `pyrefly check`(0 errors)。