### PR TITLE
♻️ refactor(core)!: 重构并统一分页体系

### DIFF
--- a/docs/coding.md
+++ b/docs/coding.md
@@ -250,7 +250,7 @@ def get_vip_info(self, *, credential: Credential | None = None):
 > 若接口需要凭证对象的字段来构建请求参数，
 > 仍可显式调用 `_require_login` 获取凭证对象。
 
-## 翻页与换一批
+## 连续翻页与批次刷新
 
 ### 连续翻页
 
@@ -283,9 +283,9 @@ def get_detail(self, songlist_id: int, num: int = 10, page: int = 1):
     ).with_extractor(lambda response: response.songs)
 ```
 
-### 换一批
+### 批次刷新 (Batch Refresh)
 
-通过 `refresh_strategy` 声明换一批能力，同理可结合 `.with_extractor()` 链式绑定数据项提取器：
+批次刷新（Batch Refresh）是一种针对推荐或关联接口、支持游标复位与防循环重复游标的特殊游标分页，同样通过 `pager_strategy` 声明：
 
 ```python
 from ..core.pagination import BatchRefreshStrategy
@@ -299,7 +299,7 @@ def get_related_mv(self, songid: int, last_mvid: str | None = None):
         method="GetSongRelatedMv",
         param={"songid": str(songid), "songtype": 1, "lastmvid": last_mvid or 0},
         response_model=GetRelatedMvResponse,
-        refresh_strategy=BatchRefreshStrategy[GetRelatedMvResponse](
+        pager_strategy=BatchRefreshStrategy[GetRelatedMvResponse](
             refresh_key="lastmvid",
             cursor_extractor=lambda response: response.mv[-1].id if response.mv else None,
             has_more_extractor=lambda response: bool(response.has_more),
@@ -315,9 +315,7 @@ def get_related_mv(self, songid: int, last_mvid: str | None = None):
 | `OffsetStrategy`                 |   偏移量滑窗 | `offset_key` + `page_size_key`  |
 | `CursorStrategy`                 | 响应游标回写 | `cursor_key`                    |
 | `MultiFieldContinuationStrategy` |   多字段续翻 | 自定义 `build_next_params` 函数 |
-| `BatchRefreshStrategy`           |       换一批 | `refresh_key`                   |
-
-`pager_strategy` 与 `refresh_strategy` 不能同时声明。
+| `BatchRefreshStrategy`           |     批次刷新 | `refresh_key`                   |
 
 ## 请求签名
 

--- a/docs/coding.md
+++ b/docs/coding.md
@@ -66,6 +66,7 @@ class FooApi(ApiModule):
 # qqmusic_api/core/client.py
 from functools import cached_property
 
+
 class Client:
     @cached_property
     def foo(self) -> "FooApi":
@@ -81,9 +82,9 @@ API 方法返回 `Request` 对象，不直接发起请求。使用 `self._build_
 def get_detail(self, song_id: int):
     """获取歌曲详情."""
     return self._build_request(
-        module="music.songDetail",       # 接口所属模块
-        method="GetDetail",              # 方法名
-        param={"songid": song_id},       # 业务参数
+        module="music.songDetail",  # 接口所属模块
+        method="GetDetail",  # 方法名
+        param={"songid": song_id},  # 业务参数
     )
 ```
 
@@ -103,20 +104,20 @@ async def quick_search(self, keyword: str) -> dict[str, Any]:
 
 ### `_build_request` 参数说明
 
-| 参数               | 类型                          | 说明                                                      |
-|--------------------|-------------------------------|-----------------------------------------------------------|
-| `module`           | `str`                         | 接口所属模块名                                            |
-| `method`           | `str`                         | 方法名                                                    |
-| `param`            | `dict`                        | 业务参数                                                  |
-| `response_model`   | `type[BaseModel]` 或 `None`   | 响应模型，为 None 时返回原始 dict                         |
-| `comm`             | `dict` 或 `None`              | 附加的公共参数                                            |
-| `override_comm`    | `bool`                        | 为 True 时 `comm` 完全替代自动生成的参数；为 False 时合并 |
-| `credential`       | `Credential` 或 `None`        | 覆盖本次请求的凭证                                        |
-| `platform`         | `Platform` 或 `None`          | 覆盖本次请求的平台                                        |
-| `preserve_bool`    | `bool`                        | 是否保留布尔值原样（默认转为 0/1 整型）                   |
-| `sign`             | `bool`                        | 是否对请求进行签名                                        |
-| `pager_strategy`   | `PagerStrategy` 或 `None`     | 分页策略，提供后返回 `PaginatedRequest`                   |
-| `refresh_strategy` | `RefresherStrategy` 或 `None` | 换一批策略，提供后返回 `RefreshableRequest`               |
+| 参数               | 类型                          | 说明                                                                    |
+|--------------------|-------------------------------|-------------------------------------------------------------------------|
+| `module`           | `str`                         | 接口所属模块名                                                          |
+| `method`           | `str`                         | 方法名                                                                  |
+| `param`            | `dict`                        | 业务参数                                                                |
+| `response_model`   | `type[BaseModel]` 或 `None`   | 响应模型，为 None 时返回原始 dict                                       |
+| `comm`             | `dict` 或 `None`              | 附加的公共参数                                                          |
+| `override_comm`    | `bool`                        | 为 True 时 `comm` 完全替代自动生成的参数；为 False 时合并               |
+| `credential`       | `Credential` 或 `None`        | 覆盖本次请求的凭证                                                      |
+| `platform`         | `Platform` 或 `None`          | 覆盖本次请求的平台                                                      |
+| `preserve_bool`    | `bool`                        | 是否保留布尔值原样（默认转为 0/1 整型）                                 |
+| `sign`             | `bool`                        | 是否对请求进行签名                                                      |
+| `pager_strategy`   | `PagerStrategy` 或 `None`     | 分页策略，提供后返回 `ItemPaginatedRequest` 或 `PaginatedRequest`       |
+| `refresh_strategy` | `RefresherStrategy` 或 `None` | 换一批策略，提供后返回 `ItemRefreshableRequest` 或 `RefreshableRequest` |
 
 ### `client.request` 参数说明
 
@@ -253,7 +254,8 @@ def get_vip_info(self, *, credential: Credential | None = None):
 
 ### 连续翻页
 
-通过 `pager_strategy` 声明连续翻页能力，建议配合显示 Generic 标注（形如 `OffsetStrategy[Any, GetSonglistDetailResponse, Song]`）以确保 IDE 的类型推断能力：
+通过 `pager_strategy` 声明连续翻页能力，建议配合显示 Generic 标注（形如
+`OffsetStrategy[Any, GetSonglistDetailResponse, Song]`）以确保 IDE 的类型推断能力：
 
 ```python
 from typing import Any
@@ -371,13 +373,14 @@ self._build_request(
 
 ## 异常处理
 
-在抛出或处理异常时，应使用项目统一的基于领域驱动（DDD）风格的异常类（继承自 `BaseApiException` 或 `ApiException`）。在包装底层异常时，必须使用原生异常链（`raise ... from exc`）保留堆栈追踪：
+在抛出或处理异常时，应使用项目统一的基于领域驱动（DDD）风格的异常类（继承自 `BaseApiException` 或 `ApiException`
+）。在包装底层异常时，必须使用原生异常链（`raise ... from exc`）保留堆栈追踪：
 
 ```python
 from ..core.exceptions import ApiDataError
 
 try:
-    # ...
+# ...
 except KeyError as e:
     raise ApiDataError("无法解析歌曲信息") from e
 ```
@@ -416,7 +419,7 @@ async def test_general_search(client: Client, page: int) -> None:
         if "limit" in str(e).lower() or "risk" in str(e).lower():
             pytest.skip(f"Triggered rate limit or risk control: {e}")
         raise
-        
+
     assert result.song.items is not None
 ```
 

--- a/docs/coding.md
+++ b/docs/coding.md
@@ -103,20 +103,20 @@ async def quick_search(self, keyword: str) -> dict[str, Any]:
 
 ### `_build_request` 参数说明
 
-| 参数             | 类型                        | 说明                                                      |
-|------------------|-----------------------------|-----------------------------------------------------------|
-| `module`         | `str`                       | 接口所属模块名                                            |
-| `method`         | `str`                       | 方法名                                                    |
-| `param`          | `dict`                      | 业务参数                                                  |
-| `response_model` | `type[BaseModel]` 或 `None` | 响应模型，为 None 时返回原始 dict                         |
-| `comm`           | `dict` 或 `None`            | 附加的公共参数                                            |
-| `override_comm`  | `bool`                      | 为 True 时 `comm` 完全替代自动生成的参数；为 False 时合并 |
-| `credential`     | `Credential` 或 `None`      | 覆盖本次请求的凭证                                        |
-| `platform`       | `Platform` 或 `None`        | 覆盖本次请求的平台                                        |
-| `preserve_bool`  | `bool`                      | 是否保留布尔值原样（默认转为 0/1 整型）                   |
-| `sign`           | `bool`                      | 是否对请求进行签名                                        |
-| `pager_meta`     | `PagerMeta` 或 `None`       | 分页元数据，提供后返回 `PaginatedRequest`                 |
-| `refresh_meta`   | `RefreshMeta` 或 `None`     | 换一批元数据，提供后返回 `RefreshableRequest`             |
+| 参数               | 类型                          | 说明                                                      |
+|--------------------|-------------------------------|-----------------------------------------------------------|
+| `module`           | `str`                         | 接口所属模块名                                            |
+| `method`           | `str`                         | 方法名                                                    |
+| `param`            | `dict`                        | 业务参数                                                  |
+| `response_model`   | `type[BaseModel]` 或 `None`   | 响应模型，为 None 时返回原始 dict                         |
+| `comm`             | `dict` 或 `None`              | 附加的公共参数                                            |
+| `override_comm`    | `bool`                        | 为 True 时 `comm` 完全替代自动生成的参数；为 False 时合并 |
+| `credential`       | `Credential` 或 `None`        | 覆盖本次请求的凭证                                        |
+| `platform`         | `Platform` 或 `None`          | 覆盖本次请求的平台                                        |
+| `preserve_bool`    | `bool`                        | 是否保留布尔值原样（默认转为 0/1 整型）                   |
+| `sign`             | `bool`                        | 是否对请求进行签名                                        |
+| `pager_strategy`   | `PagerStrategy` 或 `None`     | 分页策略，提供后返回 `PaginatedRequest`                   |
+| `refresh_strategy` | `RefresherStrategy` 或 `None` | 换一批策略，提供后返回 `RefreshableRequest`               |
 
 ### `client.request` 参数说明
 
@@ -174,6 +174,17 @@ class MyResponse(Response):
 ```
 
 `Response` 基类配置了 `frozen=True`（不可变）和 `extra="ignore"`（忽略多余字段）。
+
+!!! warning "Pydantic 默认值规范"
+
+    定义模型时应避免使用 `None` 作为隐式兜底默认值。如果字段可选或为空，应当使用显式的空标量，或通过 `Field(default_factory=...)` 声明：
+    ```python
+    class Album(Response):
+        name: str = ""
+        publish_time: str = ""
+        # 列表必须使用 default_factory
+        singers: list[Singer] = Field(default_factory=list)
+    ```
 
 ### JSONPath 字段映射
 
@@ -242,10 +253,12 @@ def get_vip_info(self, *, credential: Credential | None = None):
 
 ### 连续翻页
 
-通过 `pager_meta` 声明连续翻页能力，返回的请求对象会暴露 `.paginate()`：
+通过 `pager_strategy` 声明连续翻页能力，建议配合显示 Generic 标注（形如 `OffsetStrategy[Any, GetSonglistDetailResponse]`）以确保 IDE 的类型推断能力：
 
 ```python
-from ..core.pagination import OffsetStrategy, PagerMeta, ResponseAdapter
+from typing import Any
+
+from ..core.pagination import OffsetStrategy
 
 
 def get_detail(self, songlist_id: int, num: int = 10, page: int = 1):
@@ -259,23 +272,25 @@ def get_detail(self, songlist_id: int, num: int = 10, page: int = 1):
             "song_num": num,
         },
         response_model=GetSonglistDetailResponse,
-        pager_meta=PagerMeta(
-            strategy=OffsetStrategy(offset_key="song_begin", page_size_key="song_num"),
-            adapter=ResponseAdapter(
-                has_more_flag="hasmore",
-                total="total",
-                count=lambda response: len(response.songs),
-            ),
+        pager_strategy=OffsetStrategy[Any, GetSonglistDetailResponse](
+            offset_key="song_begin",
+            page_size_key="song_num",
+            has_more_extractor=lambda response: bool(response.hasmore),
+            total_extractor=lambda response: response.total,
+            count_extractor=lambda response: len(response.songs),
+            items_extractor=lambda response: response.songs,
         ),
     )
 ```
 
 ### 换一批
 
-通过 `refresh_meta` 声明换一批能力，返回的请求对象会暴露 `.refresh()`：
+通过 `refresh_strategy` 声明换一批能力：
 
 ```python
-from ..core.pagination import BatchRefreshStrategy, RefreshMeta, ResponseAdapter
+from typing import Any
+
+from ..core.pagination import BatchRefreshStrategy
 
 
 def get_related_mv(self, songid: int, last_mvid: str | None = None):
@@ -285,12 +300,11 @@ def get_related_mv(self, songid: int, last_mvid: str | None = None):
         method="GetSongRelatedMv",
         param={"songid": str(songid), "songtype": 1, "lastmvid": last_mvid or 0},
         response_model=GetRelatedMvResponse,
-        refresh_meta=RefreshMeta(
-            strategy=BatchRefreshStrategy(refresh_key="lastmvid"),
-            adapter=ResponseAdapter(
-                has_more_flag="has_more",
-                cursor=lambda response: response.mv[-1].id if response.mv else None,
-            ),
+        refresh_strategy=BatchRefreshStrategy[Any, GetRelatedMvResponse](
+            refresh_key="lastmvid",
+            cursor_extractor=lambda response: response.mv[-1].id if response.mv else None,
+            has_more_extractor=lambda response: bool(response.has_more),
+            items_extractor=lambda response: response.mv,
         ),
     )
 ```
@@ -305,7 +319,7 @@ def get_related_mv(self, songid: int, last_mvid: str | None = None):
 | `MultiFieldContinuationStrategy` |   多字段续翻 | 自定义 `build_next_params` 函数 |
 | `BatchRefreshStrategy`           |       换一批 | `refresh_key`                   |
 
-`pager_meta` 与 `refresh_meta` 不能同时声明。
+`pager_strategy` 与 `refresh_strategy` 不能同时声明。
 
 ## 请求签名
 
@@ -354,6 +368,19 @@ self._build_request(
 )
 ```
 
+## 异常处理
+
+在抛出或处理异常时，应使用项目统一的基于领域驱动（DDD）风格的异常类（继承自 `BaseApiException` 或 `ApiException`）。在包装底层异常时，必须使用原生异常链（`raise ... from exc`）保留堆栈追踪：
+
+```python
+from ..core.exceptions import ApiDataError
+
+try:
+    # ...
+except KeyError as e:
+    raise ApiDataError("无法解析歌曲信息") from e
+```
+
 ## 编写测试
 
 测试文件放在 `tests/` 下，按模块命名（如 `test_song.py`）。
@@ -380,8 +407,15 @@ async def test_query_song(client: Client) -> None:
 ```python
 @pytest.mark.parametrize("page", [1, 2])
 async def test_general_search(client: Client, page: int) -> None:
-    """测试综合搜索翻页."""
-    result = await client.search.general_search("周杰伦", page=page)
+    """测试综合搜索翻页逻辑."""
+    try:
+        result = await client.search.general_search("周杰伦", page=page)
+    except Exception as e:
+        # 示例：优雅处理网络风控或限流 (需根据实际异常类型调整)
+        if "limit" in str(e).lower() or "risk" in str(e).lower():
+            pytest.skip(f"Triggered rate limit or risk control: {e}")
+        raise
+        
     assert result.song.items is not None
 ```
 
@@ -401,7 +435,7 @@ async def test_get_vip_info(authenticated_client: Client) -> None:
 ```python
 async def test_search_paginate(client: Client) -> None:
     """测试搜索分页."""
-    pager = client.search.search_by_type("周杰伦", num=5).paginate(limit=2)
+    pager = client.search.search_by_type("周杰伦", num=5).pager(limit=2)
 
     assert pager.has_more() is True
     first_page = await pager.next()

--- a/docs/coding.md
+++ b/docs/coding.md
@@ -253,7 +253,7 @@ def get_vip_info(self, *, credential: Credential | None = None):
 
 ### 连续翻页
 
-通过 `pager_strategy` 声明连续翻页能力，建议配合显示 Generic 标注（形如 `OffsetStrategy[Any, GetSonglistDetailResponse]`）以确保 IDE 的类型推断能力：
+通过 `pager_strategy` 声明连续翻页能力，建议配合显示 Generic 标注（形如 `OffsetStrategy[Any, GetSonglistDetailResponse, Song]`）以确保 IDE 的类型推断能力：
 
 ```python
 from typing import Any
@@ -272,7 +272,7 @@ def get_detail(self, songlist_id: int, num: int = 10, page: int = 1):
             "song_num": num,
         },
         response_model=GetSonglistDetailResponse,
-        pager_strategy=OffsetStrategy[Any, GetSonglistDetailResponse](
+        pager_strategy=OffsetStrategy[Any, GetSonglistDetailResponse, Song](
             offset_key="song_begin",
             page_size_key="song_num",
             has_more_extractor=lambda response: bool(response.hasmore),
@@ -300,7 +300,7 @@ def get_related_mv(self, songid: int, last_mvid: str | None = None):
         method="GetSongRelatedMv",
         param={"songid": str(songid), "songtype": 1, "lastmvid": last_mvid or 0},
         response_model=GetRelatedMvResponse,
-        refresh_strategy=BatchRefreshStrategy[Any, GetRelatedMvResponse](
+        refresh_strategy=BatchRefreshStrategy[Any, GetRelatedMvResponse, Mv](
             refresh_key="lastmvid",
             cursor_extractor=lambda response: response.mv[-1].id if response.mv else None,
             has_more_extractor=lambda response: bool(response.has_more),

--- a/docs/coding.md
+++ b/docs/coding.md
@@ -291,6 +291,7 @@ def get_detail(self, songlist_id: int, num: int = 10, page: int = 1):
 from typing import Any
 
 from ..core.pagination import BatchRefreshStrategy
+from ..models.base import MV
 
 
 def get_related_mv(self, songid: int, last_mvid: str | None = None):
@@ -300,7 +301,7 @@ def get_related_mv(self, songid: int, last_mvid: str | None = None):
         method="GetSongRelatedMv",
         param={"songid": str(songid), "songtype": 1, "lastmvid": last_mvid or 0},
         response_model=GetRelatedMvResponse,
-        refresh_strategy=BatchRefreshStrategy[Any, GetRelatedMvResponse, Mv](
+        refresh_strategy=BatchRefreshStrategy[Any, GetRelatedMvResponse, MV](
             refresh_key="lastmvid",
             cursor_extractor=lambda response: response.mv[-1].id if response.mv else None,
             has_more_extractor=lambda response: bool(response.has_more),

--- a/docs/coding.md
+++ b/docs/coding.md
@@ -104,20 +104,20 @@ async def quick_search(self, keyword: str) -> dict[str, Any]:
 
 ### `_build_request` 参数说明
 
-| 参数               | 类型                          | 说明                                                                    |
-|--------------------|-------------------------------|-------------------------------------------------------------------------|
-| `module`           | `str`                         | 接口所属模块名                                                          |
-| `method`           | `str`                         | 方法名                                                                  |
-| `param`            | `dict`                        | 业务参数                                                                |
-| `response_model`   | `type[BaseModel]` 或 `None`   | 响应模型，为 None 时返回原始 dict                                       |
-| `comm`             | `dict` 或 `None`              | 附加的公共参数                                                          |
-| `override_comm`    | `bool`                        | 为 True 时 `comm` 完全替代自动生成的参数；为 False 时合并               |
-| `credential`       | `Credential` 或 `None`        | 覆盖本次请求的凭证                                                      |
-| `platform`         | `Platform` 或 `None`          | 覆盖本次请求的平台                                                      |
-| `preserve_bool`    | `bool`                        | 是否保留布尔值原样（默认转为 0/1 整型）                                 |
-| `sign`             | `bool`                        | 是否对请求进行签名                                                      |
-| `pager_strategy`   | `PagerStrategy` 或 `None`     | 分页策略，提供后返回 `ItemPaginatedRequest` 或 `PaginatedRequest`       |
-| `refresh_strategy` | `RefresherStrategy` 或 `None` | 换一批策略，提供后返回 `ItemRefreshableRequest` 或 `RefreshableRequest` |
+| 参数               | 类型                          | 说明                                                                                                        |
+|--------------------|-------------------------------|-------------------------------------------------------------------------------------------------------------|
+| `module`           | `str`                         | 接口所属模块名                                                                                              |
+| `method`           | `str`                         | 方法名                                                                                                      |
+| `param`            | `dict`                        | 业务参数                                                                                                    |
+| `response_model`   | `type[BaseModel]` 或 `None`   | 响应模型，为 None 时返回原始 dict                                                                           |
+| `comm`             | `dict` 或 `None`              | 附加的公共参数                                                                                              |
+| `override_comm`    | `bool`                        | 为 True 时 `comm` 完全替代自动生成的参数；为 False 时合并                                                   |
+| `credential`       | `Credential` 或 `None`        | 覆盖本次请求的凭证                                                                                          |
+| `platform`         | `Platform` 或 `None`          | 覆盖本次请求的平台                                                                                          |
+| `preserve_bool`    | `bool`                        | 是否保留布尔值原样（默认转为 0/1 整型）                                                                     |
+| `sign`             | `bool`                        | 是否对请求进行签名                                                                                          |
+| `pager_strategy`   | `PagerStrategy` 或 `None`     | 分页策略，提供后返回 `PaginatedRequest`；可链式调用 `.with_extractor()` 提升为 `ItemPaginatedRequest`       |
+| `refresh_strategy` | `RefresherStrategy` 或 `None` | 换一批策略，提供后返回 `RefreshableRequest`；可链式调用 `.with_extractor()` 提升为 `ItemRefreshableRequest` |
 
 ### `client.request` 参数说明
 
@@ -255,11 +255,10 @@ def get_vip_info(self, *, credential: Credential | None = None):
 ### 连续翻页
 
 通过 `pager_strategy` 声明连续翻页能力，建议配合显示 Generic 标注（形如
-`OffsetStrategy[Any, GetSonglistDetailResponse, Song]`）以确保 IDE 的类型推断能力：
+`OffsetStrategy[GetSonglistDetailResponse]`）以确保静态类型检查与类型推断的准确性，并通过 `.with_extractor()`
+链式调用绑定实体数据项的提取逻辑：
 
 ```python
-from typing import Any
-
 from ..core.pagination import OffsetStrategy
 
 
@@ -274,24 +273,21 @@ def get_detail(self, songlist_id: int, num: int = 10, page: int = 1):
             "song_num": num,
         },
         response_model=GetSonglistDetailResponse,
-        pager_strategy=OffsetStrategy[Any, GetSonglistDetailResponse, Song](
+        pager_strategy=OffsetStrategy[GetSonglistDetailResponse](
             offset_key="song_begin",
             page_size_key="song_num",
             has_more_extractor=lambda response: bool(response.hasmore),
             total_extractor=lambda response: response.total,
             count_extractor=lambda response: len(response.songs),
-            items_extractor=lambda response: response.songs,
         ),
-    )
+    ).with_extractor(lambda response: response.songs)
 ```
 
 ### 换一批
 
-通过 `refresh_strategy` 声明换一批能力：
+通过 `refresh_strategy` 声明换一批能力，同理可结合 `.with_extractor()` 链式绑定数据项提取器：
 
 ```python
-from typing import Any
-
 from ..core.pagination import BatchRefreshStrategy
 from ..models.base import MV
 
@@ -303,13 +299,12 @@ def get_related_mv(self, songid: int, last_mvid: str | None = None):
         method="GetSongRelatedMv",
         param={"songid": str(songid), "songtype": 1, "lastmvid": last_mvid or 0},
         response_model=GetRelatedMvResponse,
-        refresh_strategy=BatchRefreshStrategy[Any, GetRelatedMvResponse, MV](
+        refresh_strategy=BatchRefreshStrategy[GetRelatedMvResponse](
             refresh_key="lastmvid",
             cursor_extractor=lambda response: response.mv[-1].id if response.mv else None,
             has_more_extractor=lambda response: bool(response.has_more),
-            items_extractor=lambda response: response.mv,
         ),
-    )
+    ).with_extractor(lambda response: response.mv)
 ```
 
 ### 内置策略速查

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -76,11 +76,19 @@ uv run mkdocs serve
 * Lint 使用 [Ruff](https://docs.astral.sh/ruff/)
 * 类型检查使用 `pyrefly`
 
+## 测试规范
+
+* **专注 Modules 层**：测试重心放在 `modules` 层，将其视为黑盒。采用基于数据驱动（`@pytest.mark.parametrize`）的函数式测试方法。
+* **真实网络请求（No Mock）**：禁止 Mock 底层网络请求或核心组装逻辑。必须直接与真实的 QQ 音乐 API 交互。
+* **优雅处理限流**：触发上游 API 风控或频率限制异常时，必须捕获异常并调用 `pytest.skip()` 安全跳过，严禁导致测试失败。
+* **平铺函数写法**：摒弃测试类（`class TestXXX`），强制采用独立纯函数（Flat Functions）。
+* **无需过度清理**：对于获取、查询类操作，验证连通性与模型解析即可。
+
 ## 代码注释
 
 * 注释内容包括：模块注释、类注释、函数注释、参数类型注释、返回值注释
 * 注释风格遵循 [Google-style docstrings](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
-* 测试函数应包含单行中文 docstring（英文标点）
+* 测试用例必须包含**单行中文 docstring**，且内部必须使用**英文标点符号**。
 
 ## 文档规范
 

--- a/docs/tutorial/pagination.md
+++ b/docs/tutorial/pagination.md
@@ -2,8 +2,11 @@
 
 QQMusicApi 提供了现代化的分页与换一批支持。
 
-* `PaginatedRequest` 声明了连续翻页能力的请求。可以直接 `await` 发起单页请求，也可以通过 `.pager()`、`.paginate()`、`.collect()`、`.collect_items()` 或 `async for` 进行灵活消费。
-* `RefreshableRequest` 声明了“换一批”能力的请求。可以通过 `.refresher()`、`.refresh_stream()`、`.collect_items()` 等手控或连续刷新拉取。
+* `PaginatedRequest` 声明了连续翻页能力的请求。可以直接 `await` 发起单页请求，也可以通过 `.pager()`、`.paginate()`、
+  `.collect()` 或 `async for` 进行灵活消费。若接口支持直接解析数据项，会返回其子类 `ItemPaginatedRequest`，额外支持
+  `.collect_items()` 与 `.iter_items()`。
+* `RefreshableRequest` 声明了“换一批”能力的请求。可以通过 `.refresher()`、`.refresh_stream()` 手控或连续刷新拉取。同理，其子类
+  `ItemRefreshableRequest` 额外支持 `.collect_items()` 与 `.iter_items()` 提取实体数据。
 
 ---
 
@@ -15,11 +18,13 @@ QQMusicApi 提供了现代化的分页与换一批支持。
 import asyncio
 from qqmusic_api import Client
 
+
 async def main() -> None:
     async with Client() as client:
         # 仅获取第 1 页数据
         first_page = await client.album.get_new_album(page=1, num=10)
         print(len(first_page.albums))
+
 
 asyncio.run(main())
 ```
@@ -46,6 +51,7 @@ if req2 is not None:
 import asyncio
 from qqmusic_api import Client
 
+
 async def main() -> None:
     async with Client() as client:
         pager = client.comment.get_hot_comments(102065756, page_size=5).pager(limit=2)
@@ -53,6 +59,7 @@ async def main() -> None:
         while pager.has_more():
             page = await pager.next()
             print(len(page.comments))
+
 
 asyncio.run(main())
 ```
@@ -69,6 +76,7 @@ asyncio.run(main())
 import asyncio
 from qqmusic_api import Client
 
+
 async def main() -> None:
     async with Client() as client:
         req = client.singer.get_album_list(mid="0025NhlN2yWrP4")
@@ -81,6 +89,7 @@ async def main() -> None:
         albums = await req.collect_items(limit=25)
         print(f"共收集 {len(albums)} 个专辑实体")
 
+
 asyncio.run(main())
 ```
 
@@ -88,24 +97,30 @@ asyncio.run(main())
 
 ## 4. 异步流式迭代 (`async for`)
 
-* **页级别迭代 (`paginate()`)**：每次迭代返回一个完整的页面响应对象。
-* **条目级别迭代 (`iter_items()`)**：自动跨页提取并展平实体。
+* **页级别迭代 (`paginate()` 或直接 `async for in req`)**：每次迭代返回一个完整的 **页面响应对象 (Response)**。
+* **条目级别迭代 (`iter_items()`)**：自动跨页提取并展平 **实体数据项 (Item)**。
 
 ```python
 import asyncio
 from qqmusic_api import Client
 
+
 async def main() -> None:
     async with Client() as client:
         req = client.search.search_by_type("周杰伦", num=5)
 
-        # 方式 A：页级别迭代
+        # 方式 A1：直接对请求对象迭代 (等价于 paginate，返回完整的页面)
+        async for page in req:
+            print("当前页歌曲数:", len(page.song))
+
+        # 方式 A2：带限制的页级别迭代
         async for page in req.paginate(limit=2):
             print("当前页歌曲数:", len(page.song))
 
         # 方式 B：条目级别迭代
         async for song in req.iter_items(limit=10):
             print("歌曲名:", song.name)
+
 
 asyncio.run(main())
 ```
@@ -120,6 +135,7 @@ asyncio.run(main())
 import asyncio
 from qqmusic_api import Client
 
+
 async def main() -> None:
     async with Client() as client:
         # 手动控制器用法
@@ -128,9 +144,14 @@ async def main() -> None:
         if refresher.has_more():
             next_batch = await refresher.next()
 
-        # 连续换一批流式迭代
+        # 方式 A1：直接对请求对象迭代 (等价于 refresh_stream，返回完整的批次)
+        async for batch in client.song.get_related_mv(1114857):
+            print("最新批次 MV 数:", len(batch.mv))
+
+        # 方式 A2：带限制的连续换一批流式迭代
         async for batch in client.song.get_related_mv(1114857).refresh_stream(limit=2):
             print("最新批次 MV 数:", len(batch.mv))
+
 
 asyncio.run(main())
 ```

--- a/docs/tutorial/pagination.md
+++ b/docs/tutorial/pagination.md
@@ -1,112 +1,136 @@
 # Pagination
 
-`paginate()` 用于按页消费已经声明连续翻页能力的请求结果。
+QQMusicApi 提供了现代化的分页与换一批支持。
 
-与一次性请求单页数据不同，分页器会在每次迭代时自动请求下一页，并返回接口原本的响应模型。
+* `PaginatedRequest` 声明了连续翻页能力的请求。可以直接 `await` 发起单页请求，也可以通过 `.pager()`、`.paginate()`、`.collect()`、`.collect_items()` 或 `async for` 进行灵活消费。
+* `RefreshableRequest` 声明了“换一批”能力的请求。可以通过 `.refresher()`、`.refresh_stream()`、`.collect_items()` 等手控或连续刷新拉取。
 
-`refresh()` 则用于“换一批”接口。它不会暴露异步迭代，而是返回 `ResponseRefresher`，由调用方按需手动请求下一批。
+---
 
-## Pager 基本用法
+## 1. 单次请求与无状态步进
 
-下面的示例会连续获取搜索结果的前 3 页：
+即使请求具备分页能力，你依然可以像普通请求一样直接 `await` 它，仅拉取单页数据：
 
 ```python
 import asyncio
-
 from qqmusic_api import Client
-
 
 async def main() -> None:
     async with Client() as client:
-        pager = client.search.search_by_type("周杰伦", num=5).paginate(limit=3)
-        page_number = 1
-
-        async for page in pager:
-            print(f"第 {page_number} 页")
-            print(len(page.song))
-            page_number += 1
+        # 仅获取第 1 页数据
+        first_page = await client.album.get_new_album(page=1, num=10)
+        print(len(first_page.albums))
 
 asyncio.run(main())
 ```
 
-## Pager 手动逐页拉取
+如果你希望配合上一次响应手动构建下一页请求：
 
-如果你希望自行控制何时请求下一页, 可以配合 `has_more()` 与 `next()` 使用。`has_more()` 只读取分页器当前状态, 不会主动发起网络请求。
+```python
+req1 = client.album.get_new_album(page=1, num=10)
+res1 = await req1
 
-> `next()` 与 `async for` 的终止行为一致: 没有更多结果时会抛出 `StopAsyncIteration`。
+# 根据上一次响应获取下一次请求的描述符
+req2 = req1.next_request(res1)
+if req2 is not None:
+    res2 = await req2
+```
+
+---
+
+## 2. Pager 有状态控制器（适合 Web / UI 场景）
+
+通过 `.pager()` 可以创建一个有状态的 `AsyncPager` 控制器，包含 `has_more()` 与 `next()` 方法，极其适合 UI 的“点击下一页”交互：
 
 ```python
 import asyncio
-
 from qqmusic_api import Client
-
 
 async def main() -> None:
     async with Client() as client:
-        pager = client.comment.get_hot_comments(102065756, page_size=5).paginate(limit=2)
+        pager = client.comment.get_hot_comments(102065756, page_size=5).pager(limit=2)
 
         while pager.has_more():
             page = await pager.next()
             print(len(page.comments))
 
+asyncio.run(main())
+```
+
+> `has_more()` 只读取当前分页器的内部状态，不会发起网络请求。`next()` 没有更多数据时会抛出 `StopAsyncIteration`。
+
+---
+
+## 3. 全量收集与条目平铺 (`collect` / `collect_items`)
+
+如果你希望直接获取多页响应列表，或者直接获取展平后的所有实体数据项（如所有歌曲或专辑）：
+
+```python
+import asyncio
+from qqmusic_api import Client
+
+async def main() -> None:
+    async with Client() as client:
+        req = client.singer.get_album_list(mid="0025NhlN2yWrP4")
+
+        # 收集前 3 页的 Response 响应对象列表
+        pages = await req.collect(limit=3)
+        print(f"共获取 {len(pages)} 页响应")
+
+        # 自动跨页展开提取前 25 个专辑实体
+        albums = await req.collect_items(limit=25)
+        print(f"共收集 {len(albums)} 个专辑实体")
 
 asyncio.run(main())
 ```
 
-在第一页尚未请求前, 只要分页器未耗尽且未达到 `limit`, `has_more()` 就会返回 `True`。当上游响应已经明确没有下一页, 或者你已经达到 `limit`, `has_more()` 会变为 `False`。
+---
 
-## Pager 返回值
+## 4. 异步流式迭代 (`async for`)
 
-分页器每次迭代返回的，仍然是该接口原本的响应模型。
-
-例如：
-
-* `client.search.search_by_type(...).paginate()` 每一页返回 `SearchByTypeResponse`
-* `client.songlist.get_detail(...).paginate()` 每一页返回 `GetSonglistDetailResponse`
-
-这意味着你不需要学习新的分页包装类型，可以直接按原接口字段读取当前页数据。
-
-## Pager 限制页数
-
-`limit` 只控制最多迭代多少页，不会改写单页请求参数。
+* **页级别迭代 (`paginate()`)**：每次迭代返回一个完整的页面响应对象。
+* **条目级别迭代 (`iter_items()`)**：自动跨页提取并展平实体。
 
 ```python
 import asyncio
-
 from qqmusic_api import Client
-
 
 async def main() -> None:
     async with Client() as client:
-        pager = client.songlist.get_detail(songlist_id=7843129912, num=10).paginate(limit=2)
-        pages = [page async for page in pager]
-        print(len(pages))  # 2
+        req = client.search.search_by_type("周杰伦", num=5)
 
+        # 方式 A：页级别迭代
+        async for page in req.paginate(limit=2):
+            print("当前页歌曲数:", len(page.song))
+
+        # 方式 B：条目级别迭代
+        async for song in req.iter_items(limit=10):
+            print("歌曲名:", song.name)
 
 asyncio.run(main())
 ```
 
-如果不传 `limit`，分页器会一直请求，直到接口明确表示没有下一页。
+---
 
-## Refresher 基本用法
+## 5. Refresher 换一批用法
 
-“换一批”接口先通过 `refresh()` 取得控制器，再由控制器的 `first()` 获取当前批次，随后通过 `refresh()` 手动拉取下一批。
+“换一批”接口提供 `.refresher()` 手动控制器，以及 `.refresh_stream()` 异步流式迭代器：
 
 ```python
 import asyncio
-
 from qqmusic_api import Client
-
 
 async def main() -> None:
     async with Client() as client:
-        refresher = client.song.get_related_mv(1114857).refresh()
+        # 手动控制器用法
+        refresher = client.song.get_related_mv(1114857).refresher(limit=3)
         current_batch = await refresher.first()
-        next_batch = await refresher.refresh()
+        if refresher.has_more():
+            next_batch = await refresher.next()
 
-        print(current_batch.mv[0].id)
-        print(next_batch.mv[0].id)
-
+        # 连续换一批流式迭代
+        async for batch in client.song.get_related_mv(1114857).refresh_stream(limit=2):
+            print("最新批次 MV 数:", len(batch.mv))
 
 asyncio.run(main())
 ```

--- a/docs/tutorial/pagination.md
+++ b/docs/tutorial/pagination.md
@@ -1,12 +1,11 @@
 # Pagination
 
-QQMusicApi 提供了现代化的分页与换一批支持。
+QQMusicApi 提供了统一的分页体系：
 
-* `PaginatedRequest` 声明了连续翻页能力的请求。可以直接 `await` 发起单页请求，也可以通过 `.pager()`、`.paginate()`、
-  `.collect()` 或 `async for` 进行灵活消费。若接口支持直接解析数据项，会返回其子类 `ItemPaginatedRequest`，额外支持
-  `.collect_items()` 与 `.iter_items()`。
-* `RefreshableRequest` 声明了“换一批”能力的请求。可以通过 `.refresher()`、`.refresh_stream()` 手控或连续刷新拉取。同理，其子类
-  `ItemRefreshableRequest` 额外支持 `.collect_items()` 与 `.iter_items()` 提取实体数据。
+* **`PaginatedRequest`**：具备连续翻页与批次刷新能力的请求描述符。既可直接 `await` 获取首批响应，也可通过 `.pager()`
+  手动按需步进，或使用 `.paginate()`、`.collect()` 和 `async for` 进行流式与批量遍历。
+* **`ItemPaginatedRequest`**：具备数据项提取能力的分页扩展类。除具备通用分页方法外，还通过 `.iter_items()` 与
+  `.collect_items()` 实现了跨越页面边界、直接消费单一具体业务元素（如歌曲、专辑等）的功能。
 
 ## 1. 单次请求与无状态步进
 
@@ -39,9 +38,9 @@ if req2 is not None:
     res2 = await req2
 ```
 
-## 2. Pager 有状态控制器（适合 Web / UI 场景）
+## 2. 有状态控制器
 
-通过 `.pager()` 可以创建一个有状态的 `AsyncPager` 控制器，包含 `has_more()` 与 `next()` 方法，极其适合 UI 的“点击下一页”交互：
+通过 `.pager()` 可以创建一个有状态的 `AsyncPager` 控制器：
 
 ```python
 import asyncio
@@ -62,9 +61,10 @@ asyncio.run(main())
 
 > `has_more()` 只读取当前分页器的内部状态，不会发起网络请求。`next()` 没有更多数据时会抛出 `StopAsyncIteration`。
 
-## 3. 全量收集与条目平铺 (`collect` / `collect_items`)
+## 3. 全量收集与条目平铺
 
-如果你希望直接获取多页响应列表，或者直接获取展平后的所有实体数据项（如所有歌曲或专辑）：
+如果你希望直接获取多页响应列表，或者直接获取展平后的所有实体数据项（如所有歌曲或专辑）。为防止无休止拉取带来的耗时与风控风险，强烈建议调用时始终设置合理的
+`limit` 参数：
 
 ```python
 import asyncio
@@ -87,10 +87,7 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-## 4. 异步流式迭代 (`async for`)
-
-* **页级别迭代 (`paginate()` 或直接 `async for in req`)**：每次迭代返回一个完整的 **页面响应对象 (Response)**。
-* **条目级别迭代 (`iter_items()`)**：自动跨页提取并展平 **实体数据项 (Item)**。
+## 4. 异步流式迭代
 
 ```python
 import asyncio
@@ -101,15 +98,16 @@ async def main() -> None:
     async with Client() as client:
         req = client.search.search_by_type("周杰伦", num=5)
 
-        # 方式 A1：直接对请求对象迭代 (等价于 paginate，返回完整的页面)
+        # 方式 1：直接迭代对象本身，等价于 paginate()，连续翻页直至尾页
         async for page in req:
             print("当前页歌曲数:", len(page.song))
+            break  # 演示示例：仅处理一页后退出
 
-        # 方式 A2：带限制的页级别迭代
+        # 方式 2：显式限制最大翻页数（推荐在生产环境中为循环设置合理的上限）
         async for page in req.paginate(limit=2):
             print("当前页歌曲数:", len(page.song))
 
-        # 方式 B：条目级别迭代
+        # 方式 3：跨页条目级别迭代（自动展平为实体）
         async for song in req.iter_items(limit=10):
             print("歌曲名:", song.name)
 
@@ -117,9 +115,12 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-## 5. Refresher 换一批用法
+## 5. 批次刷新与单批次步进
 
-“换一批”接口提供 `.refresher()` 手动控制器，以及 `.refresh_stream()` 异步流式迭代器：
+部分关联或推荐类接口（如歌曲相关 MV、相似歌曲等）并非按传统的页码（Page）或偏移量（Offset）递增，而是 **按批次（Batch）** 持续更新内容。
+
+对于此类以批次刷新为主、常通过单次触发拉取的场景，推荐使用有状态的分页控制器 `.pager()` 配合 `.first()` 与 `.next()`
+精准控制每一批次的获取：
 
 ```python
 import asyncio
@@ -128,31 +129,30 @@ from qqmusic_api import Client
 
 async def main() -> None:
     async with Client() as client:
-        # 手动控制器用法
-        refresher = client.song.get_related_mv(1114857).refresher(limit=3)
-        current_batch = await refresher.first()
-        if refresher.has_more():
-            next_batch = await refresher.next()
+        # 1. 实例化分页控制器
+        pager = client.song.get_related_mv(1114857).pager()
 
-        # 方式 A1：直接对请求对象迭代 (等价于 refresh_stream，返回完整的批次)
-        async for batch in client.song.get_related_mv(1114857):
-            print("最新批次 MV 数:", len(batch.mv))
+        # 2. 首次加载页面时，拉取首批推荐数据
+        first_batch = await pager.first()
+        print("首批 MV 数量:", len(first_batch.mv))
 
-        # 方式 A2：带限制的连续换一批流式迭代
-        async for batch in client.song.get_related_mv(1114857).refresh_stream(limit=2):
-            print("最新批次 MV 数:", len(batch.mv))
+        # 3. 按需触发：调用 pager.next() 刷新拉取下一个批次
+        if pager.has_more():
+            next_batch = await pager.next()
+            print("下一批 MV 数量:", len(next_batch.mv))
 
 
 asyncio.run(main())
 ```
 
-## 6. 动态数据项提取 (`with_extractor`)
+通过 `pager().first()` 与 `pager().next()`，既能在规范的接口契约下享受自动游标维护与防重复终止保护，又能贴合按批次更新的数据消费模式。
 
-如果你使用的某个 API 返回的请求对象是原生的 `PaginatedRequest` 或 `RefreshableRequest`（即 API 层没有预设数据项提取器），你仍然可以通过
-`.with_extractor()` 动态注入一个提取逻辑。这会将请求无缝转换为具备跨页提取能力的 `ItemPaginatedRequest` 或
-`ItemRefreshableRequest`。
+## 6. 动态数据项提取
 
-这在处理一些层级较深、或者没有统一结构的响应（例如 `general_search`）时非常有用：
+如果你使用的某个 API 返回的请求对象是原生的 `PaginatedRequest`（即 API 层没有预设数据项提取器），你仍然可以通过
+`.with_extractor()` 动态注入一个提取逻辑。这会将请求无缝转换为具备跨页提取能力的 `ItemPaginatedRequest`。
+
+这在处理一些层级较深、或者没有统一结构的响应时非常有用：
 
 ```python
 import asyncio

--- a/docs/tutorial/pagination.md
+++ b/docs/tutorial/pagination.md
@@ -8,8 +8,6 @@ QQMusicApi 提供了现代化的分页与换一批支持。
 * `RefreshableRequest` 声明了“换一批”能力的请求。可以通过 `.refresher()`、`.refresh_stream()` 手控或连续刷新拉取。同理，其子类
   `ItemRefreshableRequest` 额外支持 `.collect_items()` 与 `.iter_items()` 提取实体数据。
 
----
-
 ## 1. 单次请求与无状态步进
 
 即使请求具备分页能力，你依然可以像普通请求一样直接 `await` 它，仅拉取单页数据：
@@ -41,8 +39,6 @@ if req2 is not None:
     res2 = await req2
 ```
 
----
-
 ## 2. Pager 有状态控制器（适合 Web / UI 场景）
 
 通过 `.pager()` 可以创建一个有状态的 `AsyncPager` 控制器，包含 `has_more()` 与 `next()` 方法，极其适合 UI 的“点击下一页”交互：
@@ -65,8 +61,6 @@ asyncio.run(main())
 ```
 
 > `has_more()` 只读取当前分页器的内部状态，不会发起网络请求。`next()` 没有更多数据时会抛出 `StopAsyncIteration`。
-
----
 
 ## 3. 全量收集与条目平铺 (`collect` / `collect_items`)
 
@@ -92,8 +86,6 @@ async def main() -> None:
 
 asyncio.run(main())
 ```
-
----
 
 ## 4. 异步流式迭代 (`async for`)
 
@@ -125,8 +117,6 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
----
-
 ## 5. Refresher 换一批用法
 
 “换一批”接口提供 `.refresher()` 手动控制器，以及 `.refresh_stream()` 异步流式迭代器：
@@ -151,6 +141,36 @@ async def main() -> None:
         # 方式 A2：带限制的连续换一批流式迭代
         async for batch in client.song.get_related_mv(1114857).refresh_stream(limit=2):
             print("最新批次 MV 数:", len(batch.mv))
+
+
+asyncio.run(main())
+```
+
+## 6. 动态数据项提取 (`with_extractor`)
+
+如果你使用的某个 API 返回的请求对象是原生的 `PaginatedRequest` 或 `RefreshableRequest`（即 API 层没有预设数据项提取器），你仍然可以通过
+`.with_extractor()` 动态注入一个提取逻辑。这会将请求无缝转换为具备跨页提取能力的 `ItemPaginatedRequest` 或
+`ItemRefreshableRequest`。
+
+这在处理一些层级较深、或者没有统一结构的响应（例如 `general_search`）时非常有用：
+
+```python
+import asyncio
+from qqmusic_api import Client
+
+
+async def main() -> None:
+    async with Client() as client:
+        # 这个 API 返回原生的 PaginatedRequest
+        req = client.search.general_search("周杰伦")
+
+        # 动态绑定 extractor
+        # 此时 item_req 类型变为 ItemPaginatedRequest
+        item_req = req.with_extractor(lambda r: r.song.items if r.song else [])
+
+        # 现在你可以非常自然地跨页迭代数据项了！
+        async for song in item_req.iter_items(limit=10):
+            print("提取到的歌曲:", song)
 
 
 asyncio.run(main())

--- a/qqmusic_api/core/client.py
+++ b/qqmusic_api/core/client.py
@@ -11,6 +11,7 @@ from niquests import AsyncSession, AsyncTokenBucketLimiter, PreparedRequest, Ret
 from niquests.exceptions import RequestException
 from niquests.models import Response
 from niquests.typing import AsyncHookType, ProxyType, TLSClientCertType, TLSVerifyType
+from typing_extensions import Self
 
 from ..algorithms import zzc_sign
 from ..models.request import Credential, RequestItem
@@ -278,7 +279,7 @@ class Client:
 
         return UserApi(self)
 
-    async def __aenter__(self) -> "Client":  # noqa: D105
+    async def __aenter__(self) -> Self:  # noqa: D105
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:  # noqa: D105

--- a/qqmusic_api/core/pagination.py
+++ b/qqmusic_api/core/pagination.py
@@ -1,8 +1,8 @@
 """分页与换一批核心组件定义."""
 
 import copy
-from collections.abc import Callable, Iterable
-from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeAlias, cast
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeAlias
 
 from pydantic import BaseModel
 from typing_extensions import Self, TypeVar
@@ -10,49 +10,43 @@ from typing_extensions import Self, TypeVar
 if TYPE_CHECKING:
     from .request import PaginatedRequest, RefreshableRequest
 
-T_Param = TypeVar("T_Param", bound=dict[str, Any] | dict[int, Any])
 T_Resp_contra = TypeVar("T_Resp_contra", contravariant=True)
 RequestResultT = TypeVar("RequestResultT", bound=BaseModel | dict[str, Any])
 ItemT_co = TypeVar("ItemT_co", covariant=True, default=Any)
 
-PaginationParams: TypeAlias = dict[str, Any] | dict[int, Any]
-NextParamsBuilder: TypeAlias = Callable[[T_Param, T_Resp_contra], T_Param | None]
+PaginationParams: TypeAlias = dict[str, Any]
+NextParamsBuilder: TypeAlias = Callable[[PaginationParams, T_Resp_contra], PaginationParams | None]
 
 
-class IteratorStrategy(Protocol[T_Param, T_Resp_contra, ItemT_co]):
+class IteratorStrategy(Protocol[T_Resp_contra]):
     """迭代策略协议."""
 
-    def has_next(self, params: T_Param, response: T_Resp_contra) -> bool:
+    def has_next(self, params: PaginationParams, response: T_Resp_contra) -> bool:
         """判断是否还能继续迭代."""
         ...
 
-    def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
+    def next_params(self, params: PaginationParams, response: T_Resp_contra) -> PaginationParams:
         """计算并返回下一次请求使用的全新参数字典."""
         ...
 
-    def get_items(self, response: T_Resp_contra) -> Iterable[ItemT_co] | None:
-        """从响应中提取数据项列表."""
-        ...
 
-
-class PagerStrategy(IteratorStrategy[T_Param, T_Resp_contra, ItemT_co], Protocol):
+class PagerStrategy(IteratorStrategy[T_Resp_contra], Protocol):
     """连续翻页策略协议."""
 
 
-class RefresherStrategy(IteratorStrategy[T_Param, T_Resp_contra, ItemT_co], Protocol):
+class RefresherStrategy(IteratorStrategy[T_Resp_contra], Protocol):
     """换一批策略协议."""
 
 
-class PageStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_Param, T_Resp_contra, ItemT_co]):
+class PageStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
     """基于页码的翻页策略."""
 
     def __init__(
         self,
-        page_key: str | int,
+        page_key: str,
         *,
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
         total_extractor: Callable[[T_Resp_contra], int | None] | None = None,
-        items_extractor: Callable[[T_Resp_contra], Iterable[ItemT_co] | None] | None = None,
         page_size: int | None = None,
         start_page: int = 1,
     ) -> None:
@@ -62,24 +56,16 @@ class PageStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_Pa
             page_key: 页码参数名.
             has_more_extractor: 是否还有更多数据的提取方式.
             total_extractor: 总数提取方式.
-            items_extractor: 数据项列表的提取方式.
             page_size: 每页条数.
             start_page: 起始页码.
         """
         self.page_key = page_key
         self.has_more_extractor = has_more_extractor
         self.total_extractor = total_extractor
-        self.items_extractor = items_extractor
         self.page_size = page_size
         self.start_page = start_page
 
-    def get_items(self, response: T_Resp_contra) -> Iterable[ItemT_co] | None:
-        """从响应中提取数据项列表."""
-        if self.items_extractor is not None:
-            return self.items_extractor(response)
-        return None
-
-    def has_next(self, params: T_Param, response: T_Resp_contra) -> bool:
+    def has_next(self, params: PaginationParams, response: T_Resp_contra) -> bool:
         """判断是否还能继续翻页."""
         if self.has_more_extractor is not None:
             explicit_flag = self.has_more_extractor(response)
@@ -89,8 +75,7 @@ class PageStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_Pa
         if self.total_extractor is not None and self.page_size is not None:
             total = self.total_extractor(response)
             if total is not None:
-                current_params = cast("dict[Any, Any]", params)
-                current_page = current_params.get(self.page_key, self.start_page)
+                current_page = params.get(self.page_key, self.start_page)
                 if not isinstance(current_page, int):
                     raise TypeError("分页请求缺少有效的页码参数, 无法判断是否存在下一页")
                 consumed_pages = current_page - self.start_page + 1
@@ -98,30 +83,29 @@ class PageStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_Pa
 
         return False
 
-    def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
+    def next_params(self, params: PaginationParams, response: T_Resp_contra) -> PaginationParams:
         """获取下一次请求的参数."""
-        new_params = cast("T_Param", copy.deepcopy(params))
-        current_page = cast("dict[Any, Any]", new_params).get(self.page_key, self.start_page)
+        new_params = copy.deepcopy(params)
+        current_page = new_params.get(self.page_key, self.start_page)
         if not isinstance(current_page, int):
             raise TypeError("分页请求缺少有效的页码参数, 无法计算下一页")
-        cast("dict[Any, Any]", new_params)[self.page_key] = current_page + 1
+        new_params[self.page_key] = current_page + 1
         return new_params
 
 
-class OffsetStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_Param, T_Resp_contra, ItemT_co]):
+class OffsetStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
     """基于偏移量窗口的翻页策略."""
 
     def __init__(
         self,
-        offset_key: str | int,
+        offset_key: str,
         *,
-        page_size_key: str | int | None = None,
+        page_size_key: str | None = None,
         page_size: int | None = None,
         start_offset: int = 0,
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
         total_extractor: Callable[[T_Resp_contra], int | None] | None = None,
         count_extractor: Callable[[T_Resp_contra], int | None] | None = None,
-        items_extractor: Callable[[T_Resp_contra], Iterable[ItemT_co] | None] | None = None,
     ) -> None:
         """初始化偏移量策略.
 
@@ -133,7 +117,6 @@ class OffsetStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_
             has_more_extractor: 是否还有更多数据的提取方式.
             total_extractor: 总数提取方式.
             count_extractor: 当前页实际返回数量提取方式.
-            items_extractor: 数据项列表的提取方式.
 
         Raises:
             ValueError: 当 page_size_key 和 page_size 同时缺失时抛出.
@@ -147,32 +130,25 @@ class OffsetStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_
         self.has_more_extractor = has_more_extractor
         self.total_extractor = total_extractor
         self.count_extractor = count_extractor
-        self.items_extractor = items_extractor
 
-    def get_items(self, response: T_Resp_contra) -> Iterable[ItemT_co] | None:
-        """从响应中提取数据项列表."""
-        if self.items_extractor is not None:
-            return self.items_extractor(response)
-        return None
-
-    def _resolve_page_size(self, params: T_Param) -> int:
+    def _resolve_page_size(self, params: PaginationParams) -> int:
         if self.page_size is not None:
             return self.page_size
         if self.page_size_key is None:
             raise ValueError("OffsetStrategy 配置错误: page_size_key 和 page_size 不能同时缺失")
-        page_size = cast("dict[Any, Any]", params).get(self.page_size_key)
+        page_size = params.get(self.page_size_key)
         if not isinstance(page_size, int):
             raise TypeError("分页请求缺少有效的 page_size 参数, 无法计算下一页偏移量")
         return page_size
 
-    def _resolve_step(self, params: T_Param, response: T_Resp_contra) -> int:
+    def _resolve_step(self, params: PaginationParams, response: T_Resp_contra) -> int:
         if self.count_extractor is not None:
             count = self.count_extractor(response)
             if count is not None:
                 return count
         return self._resolve_page_size(params)
 
-    def has_next(self, params: T_Param, response: T_Resp_contra) -> bool:
+    def has_next(self, params: PaginationParams, response: T_Resp_contra) -> bool:
         """检查是否有下一页."""
         if self.has_more_extractor is not None:
             explicit_flag = self.has_more_extractor(response)
@@ -182,7 +158,7 @@ class OffsetStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_
         if self.total_extractor is not None:
             total = self.total_extractor(response)
             if total is not None:
-                current_offset = cast("dict[Any, Any]", params).get(self.offset_key, self.start_offset)
+                current_offset = params.get(self.offset_key, self.start_offset)
                 if current_offset is None:
                     raise ValueError("分页请求缺少有效的 offset 参数, 无法计算下一页")
                 step = self._resolve_step(params, response)
@@ -192,31 +168,28 @@ class OffsetStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_
 
         return False
 
-    def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
+    def next_params(self, params: PaginationParams, response: T_Resp_contra) -> PaginationParams:
         """获取下一页的请求参数."""
-        new_params = cast("T_Param", copy.deepcopy(params))
-        current_offset = cast("dict[Any, Any]", new_params).get(self.offset_key, self.start_offset)
+        new_params = copy.deepcopy(params)
+        current_offset = new_params.get(self.offset_key, self.start_offset)
         if current_offset is None:
             raise ValueError("分页请求缺少有效的 offset 参数, 无法计算下一页")
         step = self._resolve_step(params, response)
         if step <= 0:
             raise ValueError("分页响应未提供有效的当前页数量, 无法计算下一页偏移量")
-        cast("dict[Any, Any]", new_params)[self.offset_key] = current_offset + step
+        new_params[self.offset_key] = current_offset + step
         return new_params
 
 
-class BatchRefreshStrategy(
-    RefresherStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_Param, T_Resp_contra, ItemT_co]
-):
+class BatchRefreshStrategy(RefresherStrategy[T_Resp_contra], Generic[T_Resp_contra]):
     """基于上一批结果标记换一批内容的策略."""
 
     def __init__(
         self,
-        refresh_key: str | int,
+        refresh_key: str,
         *,
         cursor_extractor: Callable[[T_Resp_contra], Any],
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
-        items_extractor: Callable[[T_Resp_contra], Iterable[ItemT_co] | None] | None = None,
     ) -> None:
         """初始化换一批策略.
 
@@ -224,18 +197,10 @@ class BatchRefreshStrategy(
             refresh_key: 下一次请求需要替换的参数名.
             cursor_extractor: 下一批刷新参数提取方式.
             has_more_extractor: 是否还有更多数据的提取方式.
-            items_extractor: 数据项列表的提取方式.
         """
         self.refresh_key = refresh_key
         self.cursor_extractor = cursor_extractor
         self.has_more_extractor = has_more_extractor
-        self.items_extractor = items_extractor
-
-    def get_items(self, response: T_Resp_contra) -> Iterable[ItemT_co] | None:
-        """从响应中提取数据项列表."""
-        if self.items_extractor is not None:
-            return self.items_extractor(response)
-        return None
 
     def _extract_refresh_value(self, response: T_Resp_contra) -> Any:
         refresh_value = self.cursor_extractor(response)
@@ -243,7 +208,7 @@ class BatchRefreshStrategy(
             raise ValueError("响应未提供换一批所需的刷新参数")
         return refresh_value
 
-    def has_next(self, params: T_Param, response: T_Resp_contra) -> bool:
+    def has_next(self, params: PaginationParams, response: T_Resp_contra) -> bool:
         """检查是否有下一批."""
         if self.has_more_extractor is not None:
             explicit_flag = self.has_more_extractor(response)
@@ -251,25 +216,24 @@ class BatchRefreshStrategy(
                 return False
 
         next_refresh_value = self._extract_refresh_value(response)
-        return cast("dict[Any, Any]", params).get(self.refresh_key) != next_refresh_value
+        return params.get(self.refresh_key) != next_refresh_value
 
-    def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
+    def next_params(self, params: PaginationParams, response: T_Resp_contra) -> PaginationParams:
         """获取下一批的请求参数."""
-        new_params = cast("T_Param", copy.deepcopy(params))
-        cast("dict[Any, Any]", new_params)[self.refresh_key] = self._extract_refresh_value(response)
+        new_params = copy.deepcopy(params)
+        new_params[self.refresh_key] = self._extract_refresh_value(response)
         return new_params
 
 
-class CursorStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_Param, T_Resp_contra, ItemT_co]):
+class CursorStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
     """基于响应游标回写的翻页策略."""
 
     def __init__(
         self,
-        cursor_key: str | int,
+        cursor_key: str,
         *,
         cursor_extractor: Callable[[T_Resp_contra], Any],
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
-        items_extractor: Callable[[T_Resp_contra], Iterable[ItemT_co] | None] | None = None,
     ) -> None:
         """初始化游标翻页策略.
 
@@ -277,18 +241,10 @@ class CursorStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_
             cursor_key: 下一页游标写回的请求参数名.
             cursor_extractor: 下一页游标提取方式.
             has_more_extractor: 是否还有更多数据的提取方式.
-            items_extractor: 数据项列表的提取方式.
         """
         self.cursor_key = cursor_key
         self.cursor_extractor = cursor_extractor
         self.has_more_extractor = has_more_extractor
-        self.items_extractor = items_extractor
-
-    def get_items(self, response: T_Resp_contra) -> Iterable[ItemT_co] | None:
-        """从响应中提取数据项列表."""
-        if self.items_extractor is not None:
-            return self.items_extractor(response)
-        return None
 
     def _extract_cursor(self, response: T_Resp_contra) -> Any:
         cursor = self.cursor_extractor(response)
@@ -296,7 +252,7 @@ class CursorStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_
             raise ValueError("分页响应未提供下一页游标, 无法继续翻页")
         return cursor
 
-    def has_next(self, params: T_Param, response: T_Resp_contra) -> bool:
+    def has_next(self, params: PaginationParams, response: T_Resp_contra) -> bool:
         """检查是否有下一页."""
         if self.has_more_extractor is not None:
             explicit_flag = self.has_more_extractor(response)
@@ -304,26 +260,23 @@ class CursorStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_
                 return False
 
         next_cursor = self._extract_cursor(response)
-        return cast("dict[Any, Any]", params).get(self.cursor_key) != next_cursor
+        return params.get(self.cursor_key) != next_cursor
 
-    def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
+    def next_params(self, params: PaginationParams, response: T_Resp_contra) -> PaginationParams:
         """获取下一页的请求参数."""
-        new_params = cast("T_Param", copy.deepcopy(params))
-        cast("dict[Any, Any]", new_params)[self.cursor_key] = self._extract_cursor(response)
+        new_params = copy.deepcopy(params)
+        new_params[self.cursor_key] = self._extract_cursor(response)
         return new_params
 
 
-class MultiFieldContinuationStrategy(
-    PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_Param, T_Resp_contra, ItemT_co]
-):
+class MultiFieldContinuationStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
     """基于多字段 continuation 更新的翻页策略."""
 
     def __init__(
         self,
-        build_next_params: NextParamsBuilder[T_Param, T_Resp_contra],
+        build_next_params: NextParamsBuilder[T_Resp_contra],
         *,
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
-        items_extractor: Callable[[T_Resp_contra], Iterable[ItemT_co] | None] | None = None,
         context_name: str = "continuation",
     ) -> None:
         """初始化多字段延续翻页策略.
@@ -331,30 +284,24 @@ class MultiFieldContinuationStrategy(
         Args:
             build_next_params: 根据当前请求与响应构造下一页完整参数的函数.
             has_more_extractor: 是否还有更多数据的提取方式.
-            items_extractor: 数据项列表的提取方式.
             context_name: 错误上下文中的策略名称.
         """
         self._build_next_params = build_next_params
         self.has_more_extractor = has_more_extractor
-        self.items_extractor = items_extractor
         self.context_name = context_name
 
-    def get_items(self, response: T_Resp_contra) -> Iterable[ItemT_co] | None:
-        """从响应中提取数据项列表."""
-        if self.items_extractor is not None:
-            return self.items_extractor(response)
-        return None
+    def _build_next_params_candidate(
+        self, params: PaginationParams, response: T_Resp_contra
+    ) -> PaginationParams | None:
+        return self._build_next_params(copy.deepcopy(params), response)
 
-    def _build_next_params_candidate(self, params: T_Param, response: T_Resp_contra) -> T_Param | None:
-        return self._build_next_params(cast("T_Param", copy.deepcopy(params)), response)
-
-    def _resolve_next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
+    def _resolve_next_params(self, params: PaginationParams, response: T_Resp_contra) -> PaginationParams:
         next_params = self._build_next_params_candidate(params, response)
         if next_params is None:
             raise ValueError(f"[{self.context_name}] 分页响应未提供继续翻页所需的 continuation 数据")
         return next_params
 
-    def has_next(self, params: T_Param, response: T_Resp_contra) -> bool:
+    def has_next(self, params: PaginationParams, response: T_Resp_contra) -> bool:
         """检查是否有下一页."""
         if self.has_more_extractor is not None:
             explicit_flag = self.has_more_extractor(response)
@@ -362,39 +309,9 @@ class MultiFieldContinuationStrategy(
                 return False
         return self._build_next_params_candidate(params, response) is not None
 
-    def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
+    def next_params(self, params: PaginationParams, response: T_Resp_contra) -> PaginationParams:
         """获取下一页的请求参数."""
         return self._resolve_next_params(params, response)
-
-
-class ExtractorWrapperStrategy(Generic[T_Param, T_Resp_contra, ItemT_co]):
-    """动态组合的策略包装器, 为底层策略注入或覆盖数据项提取器."""
-
-    def __init__(
-        self,
-        base_strategy: IteratorStrategy[T_Param, T_Resp_contra, Any],
-        items_extractor: Callable[[T_Resp_contra], Iterable[ItemT_co] | None],
-    ) -> None:
-        """初始化提取器包装器.
-
-        Args:
-            base_strategy: 底层的迭代策略.
-            items_extractor: 新的数据项提取器.
-        """
-        self.base_strategy = base_strategy
-        self.items_extractor = items_extractor
-
-    def has_next(self, params: T_Param, response: T_Resp_contra) -> bool:
-        """判断是否还能继续迭代, 透传至底层策略."""
-        return self.base_strategy.has_next(params, response)
-
-    def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
-        """计算并返回下一次请求使用的全新参数字典, 透传至底层策略."""
-        return self.base_strategy.next_params(params, response)
-
-    def get_items(self, response: T_Resp_contra) -> Iterable[ItemT_co] | None:
-        """使用注入的提取器从响应中提取数据项列表."""
-        return self.items_extractor(response)
 
 
 class AsyncPager(Generic[RequestResultT]):
@@ -487,9 +404,15 @@ class AsyncRefresher(Generic[RequestResultT]):
 
         Returns:
             第一批的响应对象.
+
+        Raises:
+            StopAsyncIteration: 当达到 limit 且第一批尚未拉取时抛出.
         """
         if self._first_response is not None:
             return self._first_response
+
+        if not self.has_more():
+            raise StopAsyncIteration
 
         res = await self._initial_request
         self._first_response = res

--- a/qqmusic_api/core/pagination.py
+++ b/qqmusic_api/core/pagination.py
@@ -367,12 +367,12 @@ class MultiFieldContinuationStrategy(
         return self._resolve_next_params(params, response)
 
 
-class AsyncPager(Generic[RequestResultT, ItemT_co]):
+class AsyncPager(Generic[RequestResultT]):
     """有状态异步分页器."""
 
     def __init__(
         self,
-        initial_request: "PaginatedRequest[RequestResultT, ItemT_co]",
+        initial_request: "PaginatedRequest[RequestResultT]",
         limit: int | None = None,
     ) -> None:
         """初始化异步分页器.
@@ -381,7 +381,7 @@ class AsyncPager(Generic[RequestResultT, ItemT_co]):
             initial_request: 初始翻页请求描述符.
             limit: 最大可拉取页数限制.
         """
-        self._current_request: PaginatedRequest[RequestResultT, ItemT_co] | None = initial_request
+        self._current_request: PaginatedRequest[RequestResultT] | None = initial_request
         self._limit = limit
         self._yielded_count = 0
         self._has_more = True
@@ -423,12 +423,12 @@ class AsyncPager(Generic[RequestResultT, ItemT_co]):
         return await self.next()
 
 
-class AsyncRefresher(Generic[RequestResultT, ItemT_co]):
+class AsyncRefresher(Generic[RequestResultT]):
     """有状态换一批控制器."""
 
     def __init__(
         self,
-        initial_request: "RefreshableRequest[RequestResultT, ItemT_co]",
+        initial_request: "RefreshableRequest[RequestResultT]",
         limit: int | None = None,
     ) -> None:
         """初始化换一批控制器.
@@ -437,8 +437,8 @@ class AsyncRefresher(Generic[RequestResultT, ItemT_co]):
             initial_request: 初始换一批请求描述符.
             limit: 最大换一批次数限制.
         """
-        self._initial_request: RefreshableRequest[RequestResultT, ItemT_co] = initial_request
-        self._current_request: RefreshableRequest[RequestResultT, ItemT_co] | None = initial_request
+        self._initial_request: RefreshableRequest[RequestResultT] = initial_request
+        self._current_request: RefreshableRequest[RequestResultT] | None = initial_request
         self._limit = limit
         self._yielded_count = 0
         self._first_response: RequestResultT | None = None

--- a/qqmusic_api/core/pagination.py
+++ b/qqmusic_api/core/pagination.py
@@ -367,6 +367,36 @@ class MultiFieldContinuationStrategy(
         return self._resolve_next_params(params, response)
 
 
+class ExtractorWrapperStrategy(Generic[T_Param, T_Resp_contra, ItemT_co]):
+    """动态组合的策略包装器, 为底层策略注入或覆盖数据项提取器."""
+
+    def __init__(
+        self,
+        base_strategy: IteratorStrategy[T_Param, T_Resp_contra, Any],
+        items_extractor: Callable[[T_Resp_contra], Iterable[ItemT_co] | None],
+    ) -> None:
+        """初始化提取器包装器.
+
+        Args:
+            base_strategy: 底层的迭代策略.
+            items_extractor: 新的数据项提取器.
+        """
+        self.base_strategy = base_strategy
+        self.items_extractor = items_extractor
+
+    def has_next(self, params: T_Param, response: T_Resp_contra) -> bool:
+        """判断是否还能继续迭代, 透传至底层策略."""
+        return self.base_strategy.has_next(params, response)
+
+    def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
+        """计算并返回下一次请求使用的全新参数字典, 透传至底层策略."""
+        return self.base_strategy.next_params(params, response)
+
+    def get_items(self, response: T_Resp_contra) -> Iterable[ItemT_co] | None:
+        """使用注入的提取器从响应中提取数据项列表."""
+        return self.items_extractor(response)
+
+
 class AsyncPager(Generic[RequestResultT]):
     """有状态异步分页器."""
 

--- a/qqmusic_api/core/pagination.py
+++ b/qqmusic_api/core/pagination.py
@@ -2,10 +2,10 @@
 
 import copy
 from collections.abc import Callable, Iterable
-from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeAlias, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeAlias, cast
 
 from pydantic import BaseModel
-from typing_extensions import Self
+from typing_extensions import Self, TypeVar
 
 if TYPE_CHECKING:
     from .request import PaginatedRequest, RefreshableRequest
@@ -13,12 +13,13 @@ if TYPE_CHECKING:
 T_Param = TypeVar("T_Param", bound=dict[str, Any] | dict[int, Any])
 T_Resp_contra = TypeVar("T_Resp_contra", contravariant=True)
 RequestResultT = TypeVar("RequestResultT", bound=BaseModel | dict[str, Any])
+ItemT_co = TypeVar("ItemT_co", covariant=True, default=Any)
 
 PaginationParams: TypeAlias = dict[str, Any] | dict[int, Any]
 NextParamsBuilder: TypeAlias = Callable[[T_Param, T_Resp_contra], T_Param | None]
 
 
-class IteratorStrategy(Protocol[T_Param, T_Resp_contra]):
+class IteratorStrategy(Protocol[T_Param, T_Resp_contra, ItemT_co]):
     """迭代策略协议."""
 
     def has_next(self, params: T_Param, response: T_Resp_contra) -> bool:
@@ -29,20 +30,20 @@ class IteratorStrategy(Protocol[T_Param, T_Resp_contra]):
         """计算并返回下一次请求使用的全新参数字典."""
         ...
 
-    def get_items(self, response: T_Resp_contra) -> Iterable[Any] | None:
+    def get_items(self, response: T_Resp_contra) -> Iterable[ItemT_co] | None:
         """从响应中提取数据项列表."""
         ...
 
 
-class PagerStrategy(IteratorStrategy[T_Param, T_Resp_contra], Protocol):
+class PagerStrategy(IteratorStrategy[T_Param, T_Resp_contra, ItemT_co], Protocol):
     """连续翻页策略协议."""
 
 
-class RefresherStrategy(IteratorStrategy[T_Param, T_Resp_contra], Protocol):
+class RefresherStrategy(IteratorStrategy[T_Param, T_Resp_contra, ItemT_co], Protocol):
     """换一批策略协议."""
 
 
-class PageStrategy(PagerStrategy[T_Param, T_Resp_contra]):
+class PageStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_Param, T_Resp_contra, ItemT_co]):
     """基于页码的翻页策略."""
 
     def __init__(
@@ -51,7 +52,7 @@ class PageStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         *,
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
         total_extractor: Callable[[T_Resp_contra], int | None] | None = None,
-        items_extractor: Callable[[T_Resp_contra], Iterable[Any] | None] | None = None,
+        items_extractor: Callable[[T_Resp_contra], Iterable[ItemT_co] | None] | None = None,
         page_size: int | None = None,
         start_page: int = 1,
     ) -> None:
@@ -72,7 +73,7 @@ class PageStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         self.page_size = page_size
         self.start_page = start_page
 
-    def get_items(self, response: T_Resp_contra) -> Iterable[Any] | None:
+    def get_items(self, response: T_Resp_contra) -> Iterable[ItemT_co] | None:
         """从响应中提取数据项列表."""
         if self.items_extractor is not None:
             return self.items_extractor(response)
@@ -107,7 +108,7 @@ class PageStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         return new_params
 
 
-class OffsetStrategy(PagerStrategy[T_Param, T_Resp_contra]):
+class OffsetStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_Param, T_Resp_contra, ItemT_co]):
     """基于偏移量窗口的翻页策略."""
 
     def __init__(
@@ -120,7 +121,7 @@ class OffsetStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
         total_extractor: Callable[[T_Resp_contra], int | None] | None = None,
         count_extractor: Callable[[T_Resp_contra], int | None] | None = None,
-        items_extractor: Callable[[T_Resp_contra], Iterable[Any] | None] | None = None,
+        items_extractor: Callable[[T_Resp_contra], Iterable[ItemT_co] | None] | None = None,
     ) -> None:
         """初始化偏移量策略.
 
@@ -148,7 +149,7 @@ class OffsetStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         self.count_extractor = count_extractor
         self.items_extractor = items_extractor
 
-    def get_items(self, response: T_Resp_contra) -> Iterable[Any] | None:
+    def get_items(self, response: T_Resp_contra) -> Iterable[ItemT_co] | None:
         """从响应中提取数据项列表."""
         if self.items_extractor is not None:
             return self.items_extractor(response)
@@ -204,7 +205,9 @@ class OffsetStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         return new_params
 
 
-class BatchRefreshStrategy(RefresherStrategy[T_Param, T_Resp_contra]):
+class BatchRefreshStrategy(
+    RefresherStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_Param, T_Resp_contra, ItemT_co]
+):
     """基于上一批结果标记换一批内容的策略."""
 
     def __init__(
@@ -213,7 +216,7 @@ class BatchRefreshStrategy(RefresherStrategy[T_Param, T_Resp_contra]):
         *,
         cursor_extractor: Callable[[T_Resp_contra], Any],
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
-        items_extractor: Callable[[T_Resp_contra], Iterable[Any] | None] | None = None,
+        items_extractor: Callable[[T_Resp_contra], Iterable[ItemT_co] | None] | None = None,
     ) -> None:
         """初始化换一批策略.
 
@@ -228,7 +231,7 @@ class BatchRefreshStrategy(RefresherStrategy[T_Param, T_Resp_contra]):
         self.has_more_extractor = has_more_extractor
         self.items_extractor = items_extractor
 
-    def get_items(self, response: T_Resp_contra) -> Iterable[Any] | None:
+    def get_items(self, response: T_Resp_contra) -> Iterable[ItemT_co] | None:
         """从响应中提取数据项列表."""
         if self.items_extractor is not None:
             return self.items_extractor(response)
@@ -257,7 +260,7 @@ class BatchRefreshStrategy(RefresherStrategy[T_Param, T_Resp_contra]):
         return new_params
 
 
-class CursorStrategy(PagerStrategy[T_Param, T_Resp_contra]):
+class CursorStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_Param, T_Resp_contra, ItemT_co]):
     """基于响应游标回写的翻页策略."""
 
     def __init__(
@@ -266,7 +269,7 @@ class CursorStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         *,
         cursor_extractor: Callable[[T_Resp_contra], Any],
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
-        items_extractor: Callable[[T_Resp_contra], Iterable[Any] | None] | None = None,
+        items_extractor: Callable[[T_Resp_contra], Iterable[ItemT_co] | None] | None = None,
     ) -> None:
         """初始化游标翻页策略.
 
@@ -281,7 +284,7 @@ class CursorStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         self.has_more_extractor = has_more_extractor
         self.items_extractor = items_extractor
 
-    def get_items(self, response: T_Resp_contra) -> Iterable[Any] | None:
+    def get_items(self, response: T_Resp_contra) -> Iterable[ItemT_co] | None:
         """从响应中提取数据项列表."""
         if self.items_extractor is not None:
             return self.items_extractor(response)
@@ -310,7 +313,9 @@ class CursorStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         return new_params
 
 
-class MultiFieldContinuationStrategy(PagerStrategy[T_Param, T_Resp_contra]):
+class MultiFieldContinuationStrategy(
+    PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_Param, T_Resp_contra, ItemT_co]
+):
     """基于多字段 continuation 更新的翻页策略."""
 
     def __init__(
@@ -318,7 +323,7 @@ class MultiFieldContinuationStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         build_next_params: NextParamsBuilder[T_Param, T_Resp_contra],
         *,
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
-        items_extractor: Callable[[T_Resp_contra], Iterable[Any] | None] | None = None,
+        items_extractor: Callable[[T_Resp_contra], Iterable[ItemT_co] | None] | None = None,
         context_name: str = "continuation",
     ) -> None:
         """初始化多字段延续翻页策略.
@@ -334,7 +339,7 @@ class MultiFieldContinuationStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         self.items_extractor = items_extractor
         self.context_name = context_name
 
-    def get_items(self, response: T_Resp_contra) -> Iterable[Any] | None:
+    def get_items(self, response: T_Resp_contra) -> Iterable[ItemT_co] | None:
         """从响应中提取数据项列表."""
         if self.items_extractor is not None:
             return self.items_extractor(response)
@@ -362,12 +367,12 @@ class MultiFieldContinuationStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         return self._resolve_next_params(params, response)
 
 
-class AsyncPager(Generic[RequestResultT]):
+class AsyncPager(Generic[RequestResultT, ItemT_co]):
     """有状态异步分页器."""
 
     def __init__(
         self,
-        initial_request: "PaginatedRequest[RequestResultT]",
+        initial_request: "PaginatedRequest[RequestResultT, ItemT_co]",
         limit: int | None = None,
     ) -> None:
         """初始化异步分页器.
@@ -376,7 +381,7 @@ class AsyncPager(Generic[RequestResultT]):
             initial_request: 初始翻页请求描述符.
             limit: 最大可拉取页数限制.
         """
-        self._current_request: PaginatedRequest[RequestResultT] | None = initial_request
+        self._current_request: PaginatedRequest[RequestResultT, ItemT_co] | None = initial_request
         self._limit = limit
         self._yielded_count = 0
         self._has_more = True
@@ -421,12 +426,12 @@ class AsyncPager(Generic[RequestResultT]):
         return await self.next()
 
 
-class AsyncRefresher(Generic[RequestResultT]):
+class AsyncRefresher(Generic[RequestResultT, ItemT_co]):
     """有状态换一批控制器."""
 
     def __init__(
         self,
-        initial_request: "RefreshableRequest[RequestResultT]",
+        initial_request: "RefreshableRequest[RequestResultT, ItemT_co]",
         limit: int | None = None,
     ) -> None:
         """初始化换一批控制器.
@@ -435,8 +440,8 @@ class AsyncRefresher(Generic[RequestResultT]):
             initial_request: 初始换一批请求描述符.
             limit: 最大换一批次数限制.
         """
-        self._initial_request: RefreshableRequest[RequestResultT] = initial_request
-        self._current_request: RefreshableRequest[RequestResultT] | None = initial_request
+        self._initial_request: RefreshableRequest[RequestResultT, ItemT_co] = initial_request
+        self._current_request: RefreshableRequest[RequestResultT, ItemT_co] | None = initial_request
         self._limit = limit
         self._yielded_count = 0
         self._first_response: RequestResultT | None = None

--- a/qqmusic_api/core/pagination.py
+++ b/qqmusic_api/core/pagination.py
@@ -43,6 +43,7 @@ class PageStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
         *,
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
         total_extractor: Callable[[T_Resp_contra], int | None] | None = None,
+        count_extractor: Callable[[T_Resp_contra], int | None] | None = None,
         page_size: int | None = None,
         start_page: int = 1,
     ) -> None:
@@ -52,12 +53,14 @@ class PageStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
             page_key: 页码参数名.
             has_more_extractor: 是否还有更多数据的提取方式.
             total_extractor: 总数提取方式.
+            count_extractor: 当前页条目数量提取方式.
             page_size: 每页条数.
             start_page: 起始页码.
         """
         self.page_key = page_key
         self.has_more_extractor = has_more_extractor
         self.total_extractor = total_extractor
+        self.count_extractor = count_extractor
         self.page_size = page_size
         self.start_page = start_page
 
@@ -76,6 +79,13 @@ class PageStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
                     raise TypeError("分页请求缺少有效的页码参数, 无法判断是否存在下一页")
                 consumed_pages = current_page - self.start_page + 1
                 return consumed_pages * self.page_size < total
+
+        if self.count_extractor is not None:
+            count = self.count_extractor(response)
+            if count is not None:
+                if self.page_size is not None:
+                    return count >= self.page_size and count > 0
+                return count > 0
 
         return False
 
@@ -162,6 +172,12 @@ class OffsetStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
                     return False
                 return current_offset + step < total
 
+        if self.count_extractor is not None:
+            count = self.count_extractor(response)
+            if count is not None:
+                page_size = self._resolve_page_size(params)
+                return count >= page_size and count > 0
+
         return False
 
     def next_params(self, params: PaginationParams, response: T_Resp_contra) -> PaginationParams:
@@ -186,6 +202,8 @@ class CursorStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
         *,
         cursor_extractor: Callable[[T_Resp_contra], Any],
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
+        count_extractor: Callable[[T_Resp_contra], int | None] | None = None,
+        page_size: int | None = None,
     ) -> None:
         """初始化游标翻页策略.
 
@@ -193,10 +211,14 @@ class CursorStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
             cursor_key: 下一页游标写回的请求参数名.
             cursor_extractor: 下一页游标提取方式.
             has_more_extractor: 是否还有更多数据的提取方式.
+            count_extractor: 当前页条目数量提取方式.
+            page_size: 每页条数.
         """
         self.cursor_key = cursor_key
         self.cursor_extractor = cursor_extractor
         self.has_more_extractor = has_more_extractor
+        self.count_extractor = count_extractor
+        self.page_size = page_size
 
     def _extract_cursor(self, response: T_Resp_contra) -> Any:
         cursor = self.cursor_extractor(response)
@@ -204,12 +226,27 @@ class CursorStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
             raise ValueError(f"分页响应未提供下一页参数: {self.cursor_key}")
         return cursor
 
-    def has_next(self, params: PaginationParams, response: T_Resp_contra) -> bool:
-        """检查是否有下一页."""
+    def _is_terminated(self, response: T_Resp_contra) -> bool:
+        """检查是否有明确的分页终止条件."""
         if self.has_more_extractor is not None:
             explicit_flag = self.has_more_extractor(response)
             if explicit_flag is not None and not explicit_flag:
-                return False
+                return True
+
+        if self.count_extractor is not None:
+            count = self.count_extractor(response)
+            if count is not None:
+                if self.page_size is not None and count < self.page_size:
+                    return True
+                if count == 0:
+                    return True
+
+        return False
+
+    def has_next(self, params: PaginationParams, response: T_Resp_contra) -> bool:
+        """检查是否有下一页."""
+        if self._is_terminated(response):
+            return False
 
         try:
             next_cursor = self._extract_cursor(response)
@@ -234,6 +271,8 @@ class BatchRefreshStrategy(CursorStrategy[T_Resp_contra]):
         *,
         cursor_extractor: Callable[[T_Resp_contra], Any],
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
+        count_extractor: Callable[[T_Resp_contra], int | None] | None = None,
+        page_size: int | None = None,
         allow_repeat: bool = False,
     ) -> None:
         """初始化换一批策略.
@@ -242,21 +281,23 @@ class BatchRefreshStrategy(CursorStrategy[T_Resp_contra]):
             refresh_key: 下一次请求需要替换的参数名.
             cursor_extractor: 下一批刷新参数提取方式.
             has_more_extractor: 是否还有更多数据的提取方式.
+            count_extractor: 当前页条目数量提取方式.
+            page_size: 每页条数.
             allow_repeat: 是否允许在游标不变或无新游标时重复刷新.
         """
         super().__init__(
             cursor_key=refresh_key,
             cursor_extractor=cursor_extractor,
             has_more_extractor=has_more_extractor,
+            count_extractor=count_extractor,
+            page_size=page_size,
         )
         self.allow_repeat = allow_repeat
 
     def has_next(self, params: PaginationParams, response: T_Resp_contra) -> bool:
         """检查是否有下一批."""
-        if self.has_more_extractor is not None:
-            explicit_flag = self.has_more_extractor(response)
-            if explicit_flag is not None and not explicit_flag:
-                return False
+        if self._is_terminated(response):
+            return False
 
         if self.allow_repeat:
             try:
@@ -276,6 +317,8 @@ class MultiFieldContinuationStrategy(PagerStrategy[T_Resp_contra], Generic[T_Res
         build_next_params: NextParamsBuilder[T_Resp_contra],
         *,
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
+        count_extractor: Callable[[T_Resp_contra], int | None] | None = None,
+        page_size: int | None = None,
         context_name: str = "continuation",
     ) -> None:
         """初始化多字段延续翻页策略.
@@ -283,10 +326,14 @@ class MultiFieldContinuationStrategy(PagerStrategy[T_Resp_contra], Generic[T_Res
         Args:
             build_next_params: 根据当前请求与响应构造下一页完整参数的函数.
             has_more_extractor: 是否还有更多数据的提取方式.
+            count_extractor: 当前页条目数量提取方式.
+            page_size: 每页条数.
             context_name: 错误上下文中的策略名称.
         """
         self._build_next_params = build_next_params
         self.has_more_extractor = has_more_extractor
+        self.count_extractor = count_extractor
+        self.page_size = page_size
         self.context_name = context_name
 
     def _build_next_params_candidate(
@@ -300,12 +347,28 @@ class MultiFieldContinuationStrategy(PagerStrategy[T_Resp_contra], Generic[T_Res
             raise ValueError(f"[{self.context_name}] 分页响应未提供继续翻页所需的 continuation 数据")
         return next_params
 
-    def has_next(self, params: PaginationParams, response: T_Resp_contra) -> bool:
-        """检查是否有下一页."""
+    def _is_terminated(self, response: T_Resp_contra) -> bool:
+        """检查是否有明确的分页终止条件."""
         if self.has_more_extractor is not None:
             explicit_flag = self.has_more_extractor(response)
             if explicit_flag is False:
-                return False
+                return True
+
+        if self.count_extractor is not None:
+            count = self.count_extractor(response)
+            if count is not None:
+                if self.page_size is not None and count < self.page_size:
+                    return True
+                if count == 0:
+                    return True
+
+        return False
+
+    def has_next(self, params: PaginationParams, response: T_Resp_contra) -> bool:
+        """检查是否有下一页."""
+        if self._is_terminated(response):
+            return False
+
         return self._build_next_params_candidate(params, response) is not None
 
     def next_params(self, params: PaginationParams, response: T_Resp_contra) -> PaginationParams:

--- a/qqmusic_api/core/pagination.py
+++ b/qqmusic_api/core/pagination.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from typing_extensions import Self, TypeVar
 
 if TYPE_CHECKING:
-    from .request import PaginatedRequest, RefreshableRequest
+    from .request import PaginatedRequest
 
 T_Resp_contra = TypeVar("T_Resp_contra", contravariant=True)
 RequestResultT = TypeVar("RequestResultT", bound=BaseModel | dict[str, Any])
@@ -32,10 +32,6 @@ class IteratorStrategy(Protocol[T_Resp_contra]):
 
 class PagerStrategy(IteratorStrategy[T_Resp_contra], Protocol):
     """连续翻页策略协议."""
-
-
-class RefresherStrategy(IteratorStrategy[T_Resp_contra], Protocol):
-    """换一批策略协议."""
 
 
 class PageStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
@@ -181,50 +177,6 @@ class OffsetStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
         return new_params
 
 
-class BatchRefreshStrategy(RefresherStrategy[T_Resp_contra], Generic[T_Resp_contra]):
-    """基于上一批结果标记换一批内容的策略."""
-
-    def __init__(
-        self,
-        refresh_key: str,
-        *,
-        cursor_extractor: Callable[[T_Resp_contra], Any],
-        has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
-    ) -> None:
-        """初始化换一批策略.
-
-        Args:
-            refresh_key: 下一次请求需要替换的参数名.
-            cursor_extractor: 下一批刷新参数提取方式.
-            has_more_extractor: 是否还有更多数据的提取方式.
-        """
-        self.refresh_key = refresh_key
-        self.cursor_extractor = cursor_extractor
-        self.has_more_extractor = has_more_extractor
-
-    def _extract_refresh_value(self, response: T_Resp_contra) -> Any:
-        refresh_value = self.cursor_extractor(response)
-        if refresh_value is None:
-            raise ValueError("响应未提供换一批所需的刷新参数")
-        return refresh_value
-
-    def has_next(self, params: PaginationParams, response: T_Resp_contra) -> bool:
-        """检查是否有下一批."""
-        if self.has_more_extractor is not None:
-            explicit_flag = self.has_more_extractor(response)
-            if explicit_flag is not None and not explicit_flag:
-                return False
-
-        next_refresh_value = self._extract_refresh_value(response)
-        return params.get(self.refresh_key) != next_refresh_value
-
-    def next_params(self, params: PaginationParams, response: T_Resp_contra) -> PaginationParams:
-        """获取下一批的请求参数."""
-        new_params = copy.deepcopy(params)
-        new_params[self.refresh_key] = self._extract_refresh_value(response)
-        return new_params
-
-
 class CursorStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
     """基于响应游标回写的翻页策略."""
 
@@ -249,7 +201,7 @@ class CursorStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
     def _extract_cursor(self, response: T_Resp_contra) -> Any:
         cursor = self.cursor_extractor(response)
         if cursor is None:
-            raise ValueError("分页响应未提供下一页游标, 无法继续翻页")
+            raise ValueError(f"分页响应未提供下一页参数: {self.cursor_key}")
         return cursor
 
     def has_next(self, params: PaginationParams, response: T_Resp_contra) -> bool:
@@ -259,7 +211,11 @@ class CursorStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
             if explicit_flag is not None and not explicit_flag:
                 return False
 
-        next_cursor = self._extract_cursor(response)
+        try:
+            next_cursor = self._extract_cursor(response)
+        except ValueError:
+            return False
+
         return params.get(self.cursor_key) != next_cursor
 
     def next_params(self, params: PaginationParams, response: T_Resp_contra) -> PaginationParams:
@@ -267,6 +223,49 @@ class CursorStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
         new_params = copy.deepcopy(params)
         new_params[self.cursor_key] = self._extract_cursor(response)
         return new_params
+
+
+class BatchRefreshStrategy(CursorStrategy[T_Resp_contra]):
+    """基于上一批结果标记换一批内容的策略."""
+
+    def __init__(
+        self,
+        refresh_key: str,
+        *,
+        cursor_extractor: Callable[[T_Resp_contra], Any],
+        has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
+        allow_repeat: bool = False,
+    ) -> None:
+        """初始化换一批策略.
+
+        Args:
+            refresh_key: 下一次请求需要替换的参数名.
+            cursor_extractor: 下一批刷新参数提取方式.
+            has_more_extractor: 是否还有更多数据的提取方式.
+            allow_repeat: 是否允许在游标不变或无新游标时重复刷新.
+        """
+        super().__init__(
+            cursor_key=refresh_key,
+            cursor_extractor=cursor_extractor,
+            has_more_extractor=has_more_extractor,
+        )
+        self.allow_repeat = allow_repeat
+
+    def has_next(self, params: PaginationParams, response: T_Resp_contra) -> bool:
+        """检查是否有下一批."""
+        if self.has_more_extractor is not None:
+            explicit_flag = self.has_more_extractor(response)
+            if explicit_flag is not None and not explicit_flag:
+                return False
+
+        if self.allow_repeat:
+            try:
+                self._extract_cursor(response)
+                return True
+            except ValueError:
+                return False
+
+        return super().has_next(params, response)
 
 
 class MultiFieldContinuationStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
@@ -328,16 +327,46 @@ class AsyncPager(Generic[RequestResultT]):
             initial_request: 初始翻页请求描述符.
             limit: 最大可拉取页数限制.
         """
+        self._initial_request = initial_request
         self._current_request: PaginatedRequest[RequestResultT] | None = initial_request
         self._limit = limit
         self._yielded_count = 0
         self._has_more = True
+        self._first_response: RequestResultT | None = None
+        self._last_response: RequestResultT | None = None
 
     def has_more(self) -> bool:
         """判断是否还有更多页数据可拉取."""
         if self._limit is not None and self._yielded_count >= self._limit:
             return False
-        return self._has_more
+        if self._yielded_count == 0:
+            return True
+        return self._has_more and self._current_request is not None
+
+    async def first(self) -> RequestResultT:
+        """获取或拉取首批/首页响应数据.
+
+        Returns:
+            首个页面响应对象.
+
+        Raises:
+            StopAsyncIteration: 当达到 limit 且第一页尚未拉取时抛出.
+        """
+        if self._first_response is not None:
+            return self._first_response
+
+        if not self.has_more():
+            raise StopAsyncIteration
+
+        res = await self._initial_request
+        self._first_response = res
+        if self._yielded_count == 0:
+            self._yielded_count = 1
+            self._last_response = res
+            self._current_request = self._initial_request.next_request(res)
+            if self._current_request is None:
+                self._has_more = False
+        return res
 
     async def next(self) -> RequestResultT:
         """拉取并返回下一页响应数据.
@@ -353,94 +382,13 @@ class AsyncPager(Generic[RequestResultT]):
 
         req = self._current_request
         response = await req
-        self._yielded_count += 1
-
-        self._current_request = req.next_request(response)
-        if self._current_request is None:
-            self._has_more = False
-
-        return response
-
-    def __aiter__(self) -> Self:
-        """返回异步迭代器自身."""
-        return self
-
-    async def __anext__(self) -> RequestResultT:
-        """异步迭代下一个元素."""
-        return await self.next()
-
-
-class AsyncRefresher(Generic[RequestResultT]):
-    """有状态换一批控制器."""
-
-    def __init__(
-        self,
-        initial_request: "RefreshableRequest[RequestResultT]",
-        limit: int | None = None,
-    ) -> None:
-        """初始化换一批控制器.
-
-        Args:
-            initial_request: 初始换一批请求描述符.
-            limit: 最大换一批次数限制.
-        """
-        self._initial_request: RefreshableRequest[RequestResultT] = initial_request
-        self._current_request: RefreshableRequest[RequestResultT] | None = initial_request
-        self._limit = limit
-        self._yielded_count = 0
-        self._first_response: RequestResultT | None = None
-        self._last_response: RequestResultT | None = None
-
-    def has_more(self) -> bool:
-        """判断是否还能继续换一批."""
-        if self._limit is not None and self._yielded_count >= self._limit:
-            return False
-        if self._yielded_count == 0:
-            return True
-        return self._current_request is not None
-
-    async def first(self) -> RequestResultT:
-        """获取或拉取第一批响应数据.
-
-        Returns:
-            第一批的响应对象.
-
-        Raises:
-            StopAsyncIteration: 当达到 limit 且第一批尚未拉取时抛出.
-        """
-        if self._first_response is not None:
-            return self._first_response
-
-        if not self.has_more():
-            raise StopAsyncIteration
-
-        res = await self._initial_request
-        self._first_response = res
-        if self._yielded_count == 0:
-            self._yielded_count = 1
-            self._last_response = res
-            self._current_request = self._initial_request.next_request(res)
-        return res
-
-    async def next(self) -> RequestResultT:
-        """拉取并返回下一批响应数据.
-
-        Returns:
-            下一批的响应对象.
-
-        Raises:
-            StopAsyncIteration: 当没有更多批次或达到 limit 时抛出.
-        """
-        if not self.has_more() or self._current_request is None:
-            raise StopAsyncIteration
-
-        req = self._current_request
-        response = await req
         if self._first_response is None:
             self._first_response = response
         self._last_response = response
         self._yielded_count += 1
         self._current_request = req.next_request(response)
+        if self._current_request is None:
+            self._has_more = False
 
         return response
 

--- a/qqmusic_api/core/pagination.py
+++ b/qqmusic_api/core/pagination.py
@@ -1,164 +1,93 @@
 """分页与换一批核心组件定义."""
 
 import copy
-from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator, Callable
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic, TypeAlias, TypeVar, cast
+from collections.abc import Callable
+from typing import Any, Protocol, TypeAlias, TypeVar, cast
 
-from pydantic import BaseModel
+T_Param = TypeVar("T_Param", bound=dict[str, Any] | dict[int, Any])
+T_Resp_contra = TypeVar("T_Resp_contra", contravariant=True)
 
-if TYPE_CHECKING:
-    from .request import PaginatedRequest, RefreshableRequest
-
-RequestResultT = TypeVar("RequestResultT", bound=BaseModel | dict[str, Any])
 PaginationParams: TypeAlias = dict[str, Any] | dict[int, Any]
-NextParamsBuilder: TypeAlias = Callable[[PaginationParams, Any, "ResponseAdapter"], PaginationParams | None]
+NextParamsBuilder: TypeAlias = Callable[[T_Param, T_Resp_contra], T_Param | None]
 
 
-class ResponseAdapter:
-    """响应提取器, 负责从响应中提取迭代所需的核心数据."""
+class IteratorStrategy(Protocol[T_Param, T_Resp_contra]):
+    """迭代策略协议."""
+
+    def has_next(self, params: T_Param, response: T_Resp_contra) -> bool:
+        """判断是否还能继续迭代."""
+        ...
+
+    def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
+        """计算并返回下一次请求使用的全新参数字典."""
+        ...
+
+
+class PagerStrategy(IteratorStrategy[T_Param, T_Resp_contra], Protocol):
+    """连续翻页策略协议."""
+
+
+class RefresherStrategy(IteratorStrategy[T_Param, T_Resp_contra], Protocol):
+    """换一批策略协议."""
+
+
+class PageStrategy(PagerStrategy[T_Param, T_Resp_contra]):
+    """基于页码的翻页策略."""
 
     def __init__(
         self,
-        has_more_flag: str | Callable[[Any], bool] | None = None,
-        total: str | Callable[[Any], int] | None = None,
-        cursor: str | Callable[[Any], Any] | None = None,
-        count: str | Callable[[Any], int] | None = None,
+        page_key: str | int,
+        *,
+        has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
+        total_extractor: Callable[[T_Resp_contra], int | None] | None = None,
+        page_size: int | None = None,
+        start_page: int = 1,
     ) -> None:
-        """初始化响应提取器.
-
-        Args:
-            has_more_flag: 是否还有更多数据的标志位提取方式.
-            total: 总数提取方式.
-            cursor: 下一页游标或下一批刷新参数提取方式.
-            count: 当前页实际返回数量提取方式.
-        """
-        self._has_more_flag = has_more_flag
-        self._total = total
-        self._cursor = cursor
-        self._count = count
-
-    def _extract(self, response: Any, extractor: str | Callable[[Any], Any] | None) -> Any:
-        """从响应中提取指定字段."""
-        if extractor is None:
-            return None
-        if callable(extractor):
-            return extractor(response)
-
-        if isinstance(extractor, str):
-            current = response
-            for part in extractor.split("."):
-                current = current.get(part) if isinstance(current, dict) else getattr(current, part, None)
-                if current is None:
-                    return None
-            return current
-        return None
-
-    def get_has_more_flag(self, response: Any) -> bool | None:
-        """提取显式的 has_more 标志."""
-        return self._extract(response, self._has_more_flag)
-
-    def get_total(self, response: Any) -> int | None:
-        """提取数据总数."""
-        total = self._extract(response, self._total)
-        return total if isinstance(total, int) else None
-
-    def get_cursor(self, response: Any) -> Any | None:
-        """提取下一页游标或下一批刷新参数."""
-        return self._extract(response, self._cursor)
-
-    def get_count(self, response: Any) -> int | None:
-        """提取当前页实际返回数量."""
-        count = self._extract(response, self._count)
-        return count if isinstance(count, int) else None
-
-
-class BaseIteratorStrategy(ABC):
-    """迭代策略基类."""
-
-    @abstractmethod
-    def has_next(self, params: PaginationParams, response: Any, adapter: ResponseAdapter) -> bool:
-        """判断是否还能继续迭代.
-
-        Args:
-            params: 当前请求参数.
-            response: 当前响应数据.
-            adapter: 响应适配器.
-        """
-
-    @abstractmethod
-    def next_params(
-        self,
-        params: PaginationParams,
-        response: Any,
-        adapter: ResponseAdapter,
-    ) -> PaginationParams:
-        """计算并返回下一次请求使用的全新参数字典.
-
-        Args:
-            params: 当前请求参数.
-            response: 当前响应数据.
-            adapter: 响应适配器.
-        """
-
-
-class PagerStrategy(BaseIteratorStrategy):
-    """连续翻页策略基类."""
-
-
-class RefresherStrategy(BaseIteratorStrategy):
-    """换一批策略基类."""
-
-
-class PageStrategy(PagerStrategy):
-    """基于页码的翻页策略."""
-
-    def __init__(self, page_key: str | int, page_size: int | None = None, start_page: int = 1) -> None:
-        """初始化页码策略.
+        """初始化基于页码的翻页策略.
 
         Args:
             page_key: 页码参数名.
-            page_size: 每页条数。仅在需要根据总数推导下一页时必填。
+            has_more_extractor: 是否还有更多数据的提取方式.
+            total_extractor: 总数提取方式.
+            page_size: 每页条数.
             start_page: 起始页码.
         """
         self.page_key = page_key
+        self.has_more_extractor = has_more_extractor
+        self.total_extractor = total_extractor
         self.page_size = page_size
         self.start_page = start_page
 
-    def has_next(self, params: PaginationParams, response: Any, adapter: ResponseAdapter) -> bool:
-        """判断是否还有下一页."""
-        explicit_flag = adapter.get_has_more_flag(response)
-        if explicit_flag is not None:
-            return bool(explicit_flag)
+    def has_next(self, params: T_Param, response: T_Resp_contra) -> bool:
+        """判断是否还能继续翻页."""
+        if self.has_more_extractor is not None:
+            explicit_flag = self.has_more_extractor(response)
+            if explicit_flag is not None:
+                return explicit_flag
 
-        total = adapter.get_total(response)
-        if total is None or self.page_size is None:
-            return False
+        if self.total_extractor is not None and self.page_size is not None:
+            total = self.total_extractor(response)
+            if total is not None:
+                current_params = cast("dict[Any, Any]", params)
+                current_page = current_params.get(self.page_key, self.start_page)
+                if not isinstance(current_page, int):
+                    raise TypeError("分页请求缺少有效的页码参数, 无法判断是否存在下一页")
+                consumed_pages = current_page - self.start_page + 1
+                return consumed_pages * self.page_size < total
 
-        current_params = cast("dict[Any, Any]", params)
-        current_page = current_params.get(self.page_key, self.start_page)
-        if not isinstance(current_page, int):
-            raise TypeError("分页请求缺少有效的页码参数, 无法判断是否存在下一页")
-        consumed_pages = current_page - self.start_page + 1
-        return consumed_pages * self.page_size < total
+        return False
 
-    def next_params(
-        self,
-        params: PaginationParams,
-        response: Any,
-        adapter: ResponseAdapter,
-    ) -> PaginationParams:
-        """计算下一页参数."""
-        new_params = cast("dict[Any, Any]", copy.deepcopy(params))
-        current_page = new_params.get(self.page_key, self.start_page)
+    def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
+        """获取下一次请求的参数."""
+        new_params = cast("T_Param", copy.deepcopy(params))
+        current_page = cast("dict[Any, Any]", new_params).get(self.page_key, self.start_page)
         if not isinstance(current_page, int):
             raise TypeError("分页请求缺少有效的页码参数, 无法计算下一页")
-        new_params[self.page_key] = current_page + 1
+        cast("dict[Any, Any]", new_params)[self.page_key] = current_page + 1
         return new_params
 
 
-class OffsetStrategy(PagerStrategy):
+class OffsetStrategy(PagerStrategy[T_Param, T_Resp_contra]):
     """基于偏移量窗口的翻页策略."""
 
     def __init__(
@@ -168,6 +97,9 @@ class OffsetStrategy(PagerStrategy):
         page_size_key: str | int | None = None,
         page_size: int | None = None,
         start_offset: int = 0,
+        has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
+        total_extractor: Callable[[T_Resp_contra], int | None] | None = None,
+        count_extractor: Callable[[T_Resp_contra], int | None] | None = None,
     ) -> None:
         """初始化偏移量策略.
 
@@ -176,6 +108,9 @@ class OffsetStrategy(PagerStrategy):
             page_size_key: 每页条数参数名.
             page_size: 固定每页条数.
             start_offset: 起始偏移量.
+            has_more_extractor: 是否还有更多数据的提取方式.
+            total_extractor: 总数提取方式.
+            count_extractor: 当前页实际返回数量提取方式.
 
         Raises:
             ValueError: 当 page_size_key 和 page_size 同时缺失时抛出.
@@ -186,313 +121,186 @@ class OffsetStrategy(PagerStrategy):
         self.page_size_key = page_size_key
         self.page_size = page_size
         self.start_offset = start_offset
+        self.has_more_extractor = has_more_extractor
+        self.total_extractor = total_extractor
+        self.count_extractor = count_extractor
 
-    def _resolve_page_size(self, params: PaginationParams) -> int:
-        """解析当前请求窗口大小."""
+    def _resolve_page_size(self, params: T_Param) -> int:
         if self.page_size is not None:
             return self.page_size
-        current_params = cast("dict[Any, Any]", params)
         if self.page_size_key is None:
             raise ValueError("OffsetStrategy 配置错误: page_size_key 和 page_size 不能同时缺失")
-        page_size = current_params.get(self.page_size_key)
+        page_size = cast("dict[Any, Any]", params).get(self.page_size_key)
         if not isinstance(page_size, int):
             raise TypeError("分页请求缺少有效的 page_size 参数, 无法计算下一页偏移量")
         return page_size
 
-    def _resolve_step(self, params: PaginationParams, response: Any, adapter: ResponseAdapter) -> int:
-        """解析当前页应推进的偏移量步长."""
-        count = adapter.get_count(response)
-        if count is not None:
-            return count
+    def _resolve_step(self, params: T_Param, response: T_Resp_contra) -> int:
+        if self.count_extractor is not None:
+            count = self.count_extractor(response)
+            if count is not None:
+                return count
         return self._resolve_page_size(params)
 
-    def has_next(self, params: PaginationParams, response: Any, adapter: ResponseAdapter) -> bool:
-        """判断是否还有下一页."""
-        explicit_flag = adapter.get_has_more_flag(response)
-        if explicit_flag is not None:
-            return bool(explicit_flag)
+    def has_next(self, params: T_Param, response: T_Resp_contra) -> bool:
+        """检查是否有下一页."""
+        if self.has_more_extractor is not None:
+            explicit_flag = self.has_more_extractor(response)
+            if explicit_flag is not None:
+                return explicit_flag
 
-        total = adapter.get_total(response)
-        if total is None:
-            raise ValueError("分页响应未提供 has_more_flag 或 total, 无法判断是否存在下一页")
+        if self.total_extractor is not None:
+            total = self.total_extractor(response)
+            if total is not None:
+                current_offset = cast("dict[Any, Any]", params).get(self.offset_key, self.start_offset)
+                if current_offset is None:
+                    raise ValueError("分页请求缺少有效的 offset 参数, 无法计算下一页")
+                step = self._resolve_step(params, response)
+                if step <= 0:
+                    return False
+                return current_offset + step < total
 
-        current_params = cast("dict[Any, Any]", params)
-        current_offset = current_params.get(self.offset_key, self.start_offset)
+        raise ValueError("分页响应未提供有效的方式(如 has_more_flag, total)来判断是否存在下一页")
+
+    def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
+        """获取下一页的请求参数."""
+        new_params = cast("T_Param", copy.deepcopy(params))
+        current_offset = cast("dict[Any, Any]", new_params).get(self.offset_key, self.start_offset)
         if current_offset is None:
             raise ValueError("分页请求缺少有效的 offset 参数, 无法计算下一页")
-        step = self._resolve_step(params, response, adapter)
-        if step <= 0:
-            return False
-        return current_offset + step < total
-
-    def next_params(
-        self,
-        params: PaginationParams,
-        response: Any,
-        adapter: ResponseAdapter,
-    ) -> PaginationParams:
-        """计算下一页参数."""
-        new_params = cast("dict[Any, Any]", copy.deepcopy(params))
-        current_offset = new_params.get(self.offset_key, self.start_offset)
-        if current_offset is None:
-            raise ValueError("分页请求缺少有效的 offset 参数, 无法计算下一页")
-        step = self._resolve_step(params, response, adapter)
+        step = self._resolve_step(params, response)
         if step <= 0:
             raise ValueError("分页响应未提供有效的当前页数量, 无法计算下一页偏移量")
-        new_params[self.offset_key] = current_offset + step
+        cast("dict[Any, Any]", new_params)[self.offset_key] = current_offset + step
         return new_params
 
 
-class BatchRefreshStrategy(RefresherStrategy):
+class BatchRefreshStrategy(RefresherStrategy[T_Param, T_Resp_contra]):
     """基于上一批结果标记换一批内容的策略."""
 
-    def __init__(self, refresh_key: str | int) -> None:
+    def __init__(
+        self,
+        refresh_key: str | int,
+        *,
+        cursor_extractor: Callable[[T_Resp_contra], Any],
+        has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
+    ) -> None:
         """初始化换一批策略.
 
         Args:
-            refresh_key: 下一次请求需要替换的参数名。
+            refresh_key: 下一次请求需要替换的参数名.
+            cursor_extractor: 下一批刷新参数提取方式.
+            has_more_extractor: 是否还有更多数据的提取方式.
         """
         self.refresh_key = refresh_key
+        self.cursor_extractor = cursor_extractor
+        self.has_more_extractor = has_more_extractor
 
-    def _extract_refresh_value(self, response: Any, adapter: ResponseAdapter) -> Any:
-        """提取并校验下一批请求所需的刷新参数."""
-        refresh_value = adapter.get_cursor(response)
+    def _extract_refresh_value(self, response: T_Resp_contra) -> Any:
+        refresh_value = self.cursor_extractor(response)
         if refresh_value is None:
             raise ValueError("响应未提供换一批所需的刷新参数")
         return refresh_value
 
-    def has_next(self, params: PaginationParams, response: Any, adapter: ResponseAdapter) -> bool:
-        """判断是否还能继续换一批."""
-        explicit_flag = adapter.get_has_more_flag(response)
-        if not explicit_flag:
-            return False
-        next_refresh_value = self._extract_refresh_value(response, adapter)
-        current_params = cast("dict[Any, Any]", params)
-        return current_params.get(self.refresh_key) != next_refresh_value
+    def has_next(self, params: T_Param, response: T_Resp_contra) -> bool:
+        """检查是否有下一批."""
+        if self.has_more_extractor is not None:
+            explicit_flag = self.has_more_extractor(response)
+            if explicit_flag is not None and not explicit_flag:
+                return False
 
-    def next_params(
-        self,
-        params: PaginationParams,
-        response: Any,
-        adapter: ResponseAdapter,
-    ) -> PaginationParams:
-        """计算下一批请求参数."""
-        new_params = cast("dict[Any, Any]", copy.deepcopy(params))
-        new_params[self.refresh_key] = self._extract_refresh_value(response, adapter)
+        next_refresh_value = self._extract_refresh_value(response)
+        return cast("dict[Any, Any]", params).get(self.refresh_key) != next_refresh_value
+
+    def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
+        """获取下一批的请求参数."""
+        new_params = cast("T_Param", copy.deepcopy(params))
+        cast("dict[Any, Any]", new_params)[self.refresh_key] = self._extract_refresh_value(response)
         return new_params
 
 
-class CursorStrategy(PagerStrategy):
+class CursorStrategy(PagerStrategy[T_Param, T_Resp_contra]):
     """基于响应游标回写的翻页策略."""
 
-    def __init__(self, cursor_key: str | int) -> None:
-        """初始化游标策略.
+    def __init__(
+        self,
+        cursor_key: str | int,
+        *,
+        cursor_extractor: Callable[[T_Resp_contra], Any],
+        has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
+    ) -> None:
+        """初始化游标翻页策略.
 
         Args:
             cursor_key: 下一页游标写回的请求参数名.
+            cursor_extractor: 下一页游标提取方式.
+            has_more_extractor: 是否还有更多数据的提取方式.
         """
         self.cursor_key = cursor_key
+        self.cursor_extractor = cursor_extractor
+        self.has_more_extractor = has_more_extractor
 
-    def _extract_cursor(self, response: Any, adapter: ResponseAdapter) -> Any:
-        """提取并校验下一页游标."""
-        cursor = adapter.get_cursor(response)
+    def _extract_cursor(self, response: T_Resp_contra) -> Any:
+        cursor = self.cursor_extractor(response)
         if cursor is None:
             raise ValueError("分页响应未提供下一页游标, 无法继续翻页")
         return cursor
 
-    def has_next(self, params: PaginationParams, response: Any, adapter: ResponseAdapter) -> bool:
-        """判断是否还有下一页."""
-        explicit_flag = adapter.get_has_more_flag(response)
-        if explicit_flag is not None and not bool(explicit_flag):
-            return False
+    def has_next(self, params: T_Param, response: T_Resp_contra) -> bool:
+        """检查是否有下一页."""
+        if self.has_more_extractor is not None:
+            explicit_flag = self.has_more_extractor(response)
+            if explicit_flag is not None and not explicit_flag:
+                return False
 
-        next_cursor = self._extract_cursor(response, adapter)
-        current_params = cast("dict[Any, Any]", params)
-        return current_params.get(self.cursor_key) != next_cursor
+        next_cursor = self._extract_cursor(response)
+        return cast("dict[Any, Any]", params).get(self.cursor_key) != next_cursor
 
-    def next_params(
-        self,
-        params: PaginationParams,
-        response: Any,
-        adapter: ResponseAdapter,
-    ) -> PaginationParams:
-        """计算下一页参数."""
-        new_params = cast("dict[Any, Any]", copy.deepcopy(params))
-        new_params[self.cursor_key] = self._extract_cursor(response, adapter)
+    def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
+        """获取下一页的请求参数."""
+        new_params = cast("T_Param", copy.deepcopy(params))
+        cast("dict[Any, Any]", new_params)[self.cursor_key] = self._extract_cursor(response)
         return new_params
 
 
-class MultiFieldContinuationStrategy(PagerStrategy):
+class MultiFieldContinuationStrategy(PagerStrategy[T_Param, T_Resp_contra]):
     """基于多字段 continuation 更新的翻页策略."""
 
-    def __init__(self, build_next_params: NextParamsBuilder, *, context_name: str = "continuation") -> None:
-        """初始化多字段 continuation 策略.
+    def __init__(
+        self,
+        build_next_params: NextParamsBuilder[T_Param, T_Resp_contra],
+        *,
+        has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
+        context_name: str = "continuation",
+    ) -> None:
+        """初始化多字段延续翻页策略.
 
         Args:
             build_next_params: 根据当前请求与响应构造下一页完整参数的函数.
+            has_more_extractor: 是否还有更多数据的提取方式.
             context_name: 错误上下文中的策略名称.
         """
         self._build_next_params = build_next_params
+        self.has_more_extractor = has_more_extractor
         self.context_name = context_name
 
-    def _build_next_params_candidate(
-        self,
-        params: PaginationParams,
-        response: Any,
-        adapter: ResponseAdapter,
-    ) -> PaginationParams | None:
-        """尝试解析下一页 continuation 参数."""
-        return self._build_next_params(copy.deepcopy(params), response, adapter)
+    def _build_next_params_candidate(self, params: T_Param, response: T_Resp_contra) -> T_Param | None:
+        return self._build_next_params(cast("T_Param", copy.deepcopy(params)), response)
 
-    def _resolve_next_params(
-        self,
-        params: PaginationParams,
-        response: Any,
-        adapter: ResponseAdapter,
-    ) -> PaginationParams:
-        """解析并校验下一页 continuation 参数."""
-        next_params = self._build_next_params_candidate(params, response, adapter)
+    def _resolve_next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
+        next_params = self._build_next_params_candidate(params, response)
         if next_params is None:
-            raise ValueError("分页响应未提供继续翻页所需的 continuation 数据")
-        return cast("PaginationParams", next_params)
+            raise ValueError(f"[{self.context_name}] 分页响应未提供继续翻页所需的 continuation 数据")
+        return next_params
 
-    def has_next(self, params: PaginationParams, response: Any, adapter: ResponseAdapter) -> bool:
-        """判断是否还有下一页."""
-        explicit_flag = adapter.get_has_more_flag(response)
-        if explicit_flag is False:
-            return False
-        return self._build_next_params_candidate(params, response, adapter) is not None
+    def has_next(self, params: T_Param, response: T_Resp_contra) -> bool:
+        """检查是否有下一页."""
+        if self.has_more_extractor is not None:
+            explicit_flag = self.has_more_extractor(response)
+            if explicit_flag is False:
+                return False
+        return self._build_next_params_candidate(params, response) is not None
 
-    def next_params(
-        self,
-        params: PaginationParams,
-        response: Any,
-        adapter: ResponseAdapter,
-    ) -> PaginationParams:
-        """计算下一页参数."""
-        return self._resolve_next_params(params, response, adapter)
-
-
-@dataclass(frozen=True, slots=True)
-class PagerMeta:
-    """连续翻页元数据声明."""
-
-    strategy: PagerStrategy
-    adapter: ResponseAdapter
-
-
-@dataclass(frozen=True, slots=True)
-class RefreshMeta:
-    """换一批元数据声明."""
-
-    strategy: RefresherStrategy
-    adapter: ResponseAdapter
-
-
-class _BaseResponseAdvancer(Generic[RequestResultT]):
-    """响应推进器共享执行骨架."""
-
-    def __init__(self, initial_request: Any) -> None:
-        """初始化响应推进器.
-
-        Args:
-            initial_request: 初始请求对象.
-        """
-        self._next_request = initial_request
-
-    @abstractmethod
-    def _get_meta(self, request: Any) -> PagerMeta | RefreshMeta:
-        """读取当前请求声明的迭代元数据."""
-
-    async def _advance(self) -> RequestResultT:
-        """执行当前请求并推进到下一次请求状态."""
-        if self._next_request is None:
-            raise StopAsyncIteration
-
-        current_request = self._next_request
-        response = await current_request
-        meta = self._get_meta(current_request)
-
-        if meta.strategy.has_next(current_request.param, response, meta.adapter):
-            next_param = meta.strategy.next_params(current_request.param, response, meta.adapter)
-            self._next_request = current_request.replace(param=next_param)
-        else:
-            self._next_request = None
-
-        return response
-
-
-class ResponsePager(_BaseResponseAdvancer[RequestResultT], AsyncIterator[RequestResultT]):
-    """按页消费请求结果的异步分页器."""
-
-    def __init__(self, initial_request: "PaginatedRequest[RequestResultT]", limit: int | None = None) -> None:
-        """初始化分页器.
-
-        Args:
-            initial_request: 已声明连续翻页元数据的初始请求对象.
-            limit: 最多返回的页数。传 `None` 表示按上游分页信号一直获取。
-        """
-        super().__init__(initial_request)
-        self._limit = limit
-        self._yielded_count = 0
-
-    def _can_advance(self) -> bool:
-        """返回当前分页器是否还能继续产出下一页."""
-        if self._next_request is None:
-            return False
-        if self._limit is None:
-            return True
-        return self._yielded_count < self._limit
-
-    def __aiter__(self) -> AsyncIterator[RequestResultT]:
-        """返回分页器自身, 以支持 `async for` 迭代."""
-        return self
-
-    async def __anext__(self) -> RequestResultT:
-        """获取并返回下一页响应."""
-        if not self._can_advance():
-            raise StopAsyncIteration
-        response = await self._advance()
-        self._yielded_count += 1
-        return response
-
-    async def next(self) -> RequestResultT:
-        """获取并返回下一页响应."""
-        return await self.__anext__()
-
-    def has_more(self) -> bool:
-        """返回当前分页器是否还能继续产出下一页."""
-        return self._can_advance()
-
-    def _get_meta(self, request: "PaginatedRequest[RequestResultT]") -> PagerMeta:
-        """读取分页请求对应的连续翻页元数据."""
-        return request.get_pager_meta()
-
-
-class ResponseRefresher(_BaseResponseAdvancer[RequestResultT]):
-    """按需请求下一批结果的换一批器."""
-
-    def __init__(self, initial_request: "RefreshableRequest[RequestResultT]") -> None:
-        """初始化换一批器.
-
-        Args:
-            initial_request: 已声明换一批元数据的初始请求对象。
-        """
-        super().__init__(initial_request)
-        self._first_response: RequestResultT | None = None
-
-    def _get_meta(self, request: "RefreshableRequest[RequestResultT]") -> RefreshMeta:
-        """读取刷新请求对应的换一批元数据."""
-        return request.get_refresh_meta()
-
-    async def first(self) -> RequestResultT:
-        """请求并返回当前批结果."""
-        if self._first_response is None:
-            self._first_response = await self._advance()
-        return self._first_response
-
-    async def refresh(self) -> RequestResultT:
-        """请求并返回下一批结果."""
-        if self._first_response is None:
-            await self.first()
-        return await self._advance()
+    def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
+        """获取下一页的请求参数."""
+        return self._resolve_next_params(params, response)

--- a/qqmusic_api/core/pagination.py
+++ b/qqmusic_api/core/pagination.py
@@ -190,7 +190,7 @@ class OffsetStrategy(PagerStrategy[T_Param, T_Resp_contra, ItemT_co], Generic[T_
                     return False
                 return current_offset + step < total
 
-        raise ValueError("分页响应未提供有效的方式(如 has_more_flag, total)来判断是否存在下一页")
+        return False
 
     def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
         """获取下一页的请求参数."""
@@ -408,11 +408,8 @@ class AsyncPager(Generic[RequestResultT, ItemT_co]):
         response = await req
         self._yielded_count += 1
 
-        if req.pager_strategy.has_next(req.param, response):
-            next_param = req.pager_strategy.next_params(req.param, response)
-            self._current_request = req.replace(param=next_param)
-        else:
-            self._current_request = None
+        self._current_request = req.next_request(response)
+        if self._current_request is None:
             self._has_more = False
 
         return response

--- a/qqmusic_api/core/pagination.py
+++ b/qqmusic_api/core/pagination.py
@@ -1,11 +1,18 @@
 """分页与换一批核心组件定义."""
 
 import copy
-from collections.abc import Callable
-from typing import Any, Protocol, TypeAlias, TypeVar, cast
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeAlias, TypeVar, cast
+
+from pydantic import BaseModel
+from typing_extensions import Self
+
+if TYPE_CHECKING:
+    from .request import PaginatedRequest, RefreshableRequest
 
 T_Param = TypeVar("T_Param", bound=dict[str, Any] | dict[int, Any])
 T_Resp_contra = TypeVar("T_Resp_contra", contravariant=True)
+RequestResultT = TypeVar("RequestResultT", bound=BaseModel | dict[str, Any])
 
 PaginationParams: TypeAlias = dict[str, Any] | dict[int, Any]
 NextParamsBuilder: TypeAlias = Callable[[T_Param, T_Resp_contra], T_Param | None]
@@ -20,6 +27,10 @@ class IteratorStrategy(Protocol[T_Param, T_Resp_contra]):
 
     def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
         """计算并返回下一次请求使用的全新参数字典."""
+        ...
+
+    def get_items(self, response: T_Resp_contra) -> Iterable[Any] | None:
+        """从响应中提取数据项列表."""
         ...
 
 
@@ -40,6 +51,7 @@ class PageStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         *,
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
         total_extractor: Callable[[T_Resp_contra], int | None] | None = None,
+        items_extractor: Callable[[T_Resp_contra], Iterable[Any] | None] | None = None,
         page_size: int | None = None,
         start_page: int = 1,
     ) -> None:
@@ -49,14 +61,22 @@ class PageStrategy(PagerStrategy[T_Param, T_Resp_contra]):
             page_key: 页码参数名.
             has_more_extractor: 是否还有更多数据的提取方式.
             total_extractor: 总数提取方式.
+            items_extractor: 数据项列表的提取方式.
             page_size: 每页条数.
             start_page: 起始页码.
         """
         self.page_key = page_key
         self.has_more_extractor = has_more_extractor
         self.total_extractor = total_extractor
+        self.items_extractor = items_extractor
         self.page_size = page_size
         self.start_page = start_page
+
+    def get_items(self, response: T_Resp_contra) -> Iterable[Any] | None:
+        """从响应中提取数据项列表."""
+        if self.items_extractor is not None:
+            return self.items_extractor(response)
+        return None
 
     def has_next(self, params: T_Param, response: T_Resp_contra) -> bool:
         """判断是否还能继续翻页."""
@@ -100,6 +120,7 @@ class OffsetStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
         total_extractor: Callable[[T_Resp_contra], int | None] | None = None,
         count_extractor: Callable[[T_Resp_contra], int | None] | None = None,
+        items_extractor: Callable[[T_Resp_contra], Iterable[Any] | None] | None = None,
     ) -> None:
         """初始化偏移量策略.
 
@@ -111,6 +132,7 @@ class OffsetStrategy(PagerStrategy[T_Param, T_Resp_contra]):
             has_more_extractor: 是否还有更多数据的提取方式.
             total_extractor: 总数提取方式.
             count_extractor: 当前页实际返回数量提取方式.
+            items_extractor: 数据项列表的提取方式.
 
         Raises:
             ValueError: 当 page_size_key 和 page_size 同时缺失时抛出.
@@ -124,6 +146,13 @@ class OffsetStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         self.has_more_extractor = has_more_extractor
         self.total_extractor = total_extractor
         self.count_extractor = count_extractor
+        self.items_extractor = items_extractor
+
+    def get_items(self, response: T_Resp_contra) -> Iterable[Any] | None:
+        """从响应中提取数据项列表."""
+        if self.items_extractor is not None:
+            return self.items_extractor(response)
+        return None
 
     def _resolve_page_size(self, params: T_Param) -> int:
         if self.page_size is not None:
@@ -184,6 +213,7 @@ class BatchRefreshStrategy(RefresherStrategy[T_Param, T_Resp_contra]):
         *,
         cursor_extractor: Callable[[T_Resp_contra], Any],
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
+        items_extractor: Callable[[T_Resp_contra], Iterable[Any] | None] | None = None,
     ) -> None:
         """初始化换一批策略.
 
@@ -191,10 +221,18 @@ class BatchRefreshStrategy(RefresherStrategy[T_Param, T_Resp_contra]):
             refresh_key: 下一次请求需要替换的参数名.
             cursor_extractor: 下一批刷新参数提取方式.
             has_more_extractor: 是否还有更多数据的提取方式.
+            items_extractor: 数据项列表的提取方式.
         """
         self.refresh_key = refresh_key
         self.cursor_extractor = cursor_extractor
         self.has_more_extractor = has_more_extractor
+        self.items_extractor = items_extractor
+
+    def get_items(self, response: T_Resp_contra) -> Iterable[Any] | None:
+        """从响应中提取数据项列表."""
+        if self.items_extractor is not None:
+            return self.items_extractor(response)
+        return None
 
     def _extract_refresh_value(self, response: T_Resp_contra) -> Any:
         refresh_value = self.cursor_extractor(response)
@@ -228,6 +266,7 @@ class CursorStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         *,
         cursor_extractor: Callable[[T_Resp_contra], Any],
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
+        items_extractor: Callable[[T_Resp_contra], Iterable[Any] | None] | None = None,
     ) -> None:
         """初始化游标翻页策略.
 
@@ -235,10 +274,18 @@ class CursorStrategy(PagerStrategy[T_Param, T_Resp_contra]):
             cursor_key: 下一页游标写回的请求参数名.
             cursor_extractor: 下一页游标提取方式.
             has_more_extractor: 是否还有更多数据的提取方式.
+            items_extractor: 数据项列表的提取方式.
         """
         self.cursor_key = cursor_key
         self.cursor_extractor = cursor_extractor
         self.has_more_extractor = has_more_extractor
+        self.items_extractor = items_extractor
+
+    def get_items(self, response: T_Resp_contra) -> Iterable[Any] | None:
+        """从响应中提取数据项列表."""
+        if self.items_extractor is not None:
+            return self.items_extractor(response)
+        return None
 
     def _extract_cursor(self, response: T_Resp_contra) -> Any:
         cursor = self.cursor_extractor(response)
@@ -271,6 +318,7 @@ class MultiFieldContinuationStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         build_next_params: NextParamsBuilder[T_Param, T_Resp_contra],
         *,
         has_more_extractor: Callable[[T_Resp_contra], bool | None] | None = None,
+        items_extractor: Callable[[T_Resp_contra], Iterable[Any] | None] | None = None,
         context_name: str = "continuation",
     ) -> None:
         """初始化多字段延续翻页策略.
@@ -278,11 +326,19 @@ class MultiFieldContinuationStrategy(PagerStrategy[T_Param, T_Resp_contra]):
         Args:
             build_next_params: 根据当前请求与响应构造下一页完整参数的函数.
             has_more_extractor: 是否还有更多数据的提取方式.
+            items_extractor: 数据项列表的提取方式.
             context_name: 错误上下文中的策略名称.
         """
         self._build_next_params = build_next_params
         self.has_more_extractor = has_more_extractor
+        self.items_extractor = items_extractor
         self.context_name = context_name
+
+    def get_items(self, response: T_Resp_contra) -> Iterable[Any] | None:
+        """从响应中提取数据项列表."""
+        if self.items_extractor is not None:
+            return self.items_extractor(response)
+        return None
 
     def _build_next_params_candidate(self, params: T_Param, response: T_Resp_contra) -> T_Param | None:
         return self._build_next_params(cast("T_Param", copy.deepcopy(params)), response)
@@ -304,3 +360,139 @@ class MultiFieldContinuationStrategy(PagerStrategy[T_Param, T_Resp_contra]):
     def next_params(self, params: T_Param, response: T_Resp_contra) -> T_Param:
         """获取下一页的请求参数."""
         return self._resolve_next_params(params, response)
+
+
+class AsyncPager(Generic[RequestResultT]):
+    """有状态异步分页器."""
+
+    def __init__(
+        self,
+        initial_request: "PaginatedRequest[RequestResultT]",
+        limit: int | None = None,
+    ) -> None:
+        """初始化异步分页器.
+
+        Args:
+            initial_request: 初始翻页请求描述符.
+            limit: 最大可拉取页数限制.
+        """
+        self._current_request: PaginatedRequest[RequestResultT] | None = initial_request
+        self._limit = limit
+        self._yielded_count = 0
+        self._has_more = True
+
+    def has_more(self) -> bool:
+        """判断是否还有更多页数据可拉取."""
+        if self._limit is not None and self._yielded_count >= self._limit:
+            return False
+        return self._has_more
+
+    async def next(self) -> RequestResultT:
+        """拉取并返回下一页响应数据.
+
+        Returns:
+            下一页的响应对象.
+
+        Raises:
+            StopAsyncIteration: 当没有更多页或达到 limit 时抛出.
+        """
+        if not self.has_more() or self._current_request is None:
+            raise StopAsyncIteration
+
+        req = self._current_request
+        response = await req
+        self._yielded_count += 1
+
+        if req.pager_strategy.has_next(req.param, response):
+            next_param = req.pager_strategy.next_params(req.param, response)
+            self._current_request = req.replace(param=next_param)
+        else:
+            self._current_request = None
+            self._has_more = False
+
+        return response
+
+    def __aiter__(self) -> Self:
+        """返回异步迭代器自身."""
+        return self
+
+    async def __anext__(self) -> RequestResultT:
+        """异步迭代下一个元素."""
+        return await self.next()
+
+
+class AsyncRefresher(Generic[RequestResultT]):
+    """有状态换一批控制器."""
+
+    def __init__(
+        self,
+        initial_request: "RefreshableRequest[RequestResultT]",
+        limit: int | None = None,
+    ) -> None:
+        """初始化换一批控制器.
+
+        Args:
+            initial_request: 初始换一批请求描述符.
+            limit: 最大换一批次数限制.
+        """
+        self._initial_request: RefreshableRequest[RequestResultT] = initial_request
+        self._current_request: RefreshableRequest[RequestResultT] | None = initial_request
+        self._limit = limit
+        self._yielded_count = 0
+        self._first_response: RequestResultT | None = None
+        self._last_response: RequestResultT | None = None
+
+    def has_more(self) -> bool:
+        """判断是否还能继续换一批."""
+        if self._limit is not None and self._yielded_count >= self._limit:
+            return False
+        if self._yielded_count == 0:
+            return True
+        return self._current_request is not None
+
+    async def first(self) -> RequestResultT:
+        """获取或拉取第一批响应数据.
+
+        Returns:
+            第一批的响应对象.
+        """
+        if self._first_response is not None:
+            return self._first_response
+
+        res = await self._initial_request
+        self._first_response = res
+        if self._yielded_count == 0:
+            self._yielded_count = 1
+            self._last_response = res
+            self._current_request = self._initial_request.next_request(res)
+        return res
+
+    async def next(self) -> RequestResultT:
+        """拉取并返回下一批响应数据.
+
+        Returns:
+            下一批的响应对象.
+
+        Raises:
+            StopAsyncIteration: 当没有更多批次或达到 limit 时抛出.
+        """
+        if not self.has_more() or self._current_request is None:
+            raise StopAsyncIteration
+
+        req = self._current_request
+        response = await req
+        if self._first_response is None:
+            self._first_response = response
+        self._last_response = response
+        self._yielded_count += 1
+        self._current_request = req.next_request(response)
+
+        return response
+
+    def __aiter__(self) -> Self:
+        """返回异步迭代器自身."""
+        return self
+
+    async def __anext__(self) -> RequestResultT:
+        """异步迭代下一个元素."""
+        return await self.next()

--- a/qqmusic_api/core/pagination.py
+++ b/qqmusic_api/core/pagination.py
@@ -230,8 +230,8 @@ class CursorStrategy(PagerStrategy[T_Resp_contra], Generic[T_Resp_contra]):
         """检查是否有明确的分页终止条件."""
         if self.has_more_extractor is not None:
             explicit_flag = self.has_more_extractor(response)
-            if explicit_flag is not None and not explicit_flag:
-                return True
+            if explicit_flag is not None:
+                return not explicit_flag
 
         if self.count_extractor is not None:
             count = self.count_extractor(response)
@@ -351,8 +351,8 @@ class MultiFieldContinuationStrategy(PagerStrategy[T_Resp_contra], Generic[T_Res
         """检查是否有明确的分页终止条件."""
         if self.has_more_extractor is not None:
             explicit_flag = self.has_more_extractor(response)
-            if explicit_flag is False:
-                return True
+            if explicit_flag is not None:
+                return not explicit_flag
 
         if self.count_extractor is not None:
             count = self.count_extractor(response)

--- a/qqmusic_api/core/request.py
+++ b/qqmusic_api/core/request.py
@@ -109,10 +109,10 @@ class Request(Generic[RequestResultT]):
 
 
 @dataclass
-class PaginatedRequest(Request[RequestResultT], Generic[RequestResultT, ItemT_co]):
+class PaginatedRequest(Request[RequestResultT]):
     """声明了连续翻页能力的请求描述符."""
 
-    pager_strategy: PagerStrategy[Any, RequestResultT, ItemT_co]
+    pager_strategy: PagerStrategy[Any, RequestResultT, Any]
 
     def next_request(self, previous_response: RequestResultT) -> Self | None:
         """根据上一次请求的响应, 构建下一次翻页的请求.
@@ -128,7 +128,7 @@ class PaginatedRequest(Request[RequestResultT], Generic[RequestResultT, ItemT_co
             return self.replace(param=next_param)
         return None
 
-    def pager(self, limit: int | None = None) -> AsyncPager[RequestResultT, ItemT_co]:
+    def pager(self, limit: int | None = None) -> AsyncPager[RequestResultT]:
         """返回有状态异步分页器.
 
         Args:
@@ -146,6 +146,38 @@ class PaginatedRequest(Request[RequestResultT], Generic[RequestResultT, ItemT_co
             响应对象列表.
         """
         return [response async for response in self.paginate(limit=limit)]
+
+    async def paginate(self, limit: int | None = None) -> "AsyncGenerator[RequestResultT, None]":
+        """返回响应的分页迭代器.
+
+        Args:
+            limit: 最大获取页数.
+        """
+        current_request: Request[RequestResultT] | None = self
+        yielded_count = 0
+        while current_request is not None:
+            if limit is not None and yielded_count >= limit:
+                break
+            response = await current_request
+            yield response
+            yielded_count += 1
+
+            if self.pager_strategy.has_next(current_request.param, response):
+                next_param = self.pager_strategy.next_params(current_request.param, response)
+                current_request = current_request.replace(param=next_param)
+            else:
+                current_request = None
+
+    def __aiter__(self) -> "AsyncGenerator[RequestResultT, None]":
+        """返回异步迭代器自身."""
+        return self.paginate()
+
+
+@dataclass
+class ItemPaginatedRequest(PaginatedRequest[RequestResultT], Generic[RequestResultT, ItemT_co]):
+    """声明了提取数据项能力的连续翻页请求描述符."""
+
+    pager_strategy: PagerStrategy[Any, RequestResultT, ItemT_co]
 
     async def iter_items(self, limit: int | None = None) -> "AsyncGenerator[ItemT_co, None]":
         """跨页展开提取数据项的异步迭代器.
@@ -181,39 +213,14 @@ class PaginatedRequest(Request[RequestResultT], Generic[RequestResultT, ItemT_co
         """
         return [item async for item in self.iter_items(limit=limit)]
 
-    async def paginate(self, limit: int | None = None) -> "AsyncGenerator[RequestResultT, None]":
-        """返回响应的分页迭代器.
-
-        Args:
-            limit: 最大获取页数.
-        """
-        current_request: Request[RequestResultT] | None = self
-        yielded_count = 0
-        while current_request is not None:
-            if limit is not None and yielded_count >= limit:
-                break
-            response = await current_request
-            yield response
-            yielded_count += 1
-
-            if self.pager_strategy.has_next(current_request.param, response):
-                next_param = self.pager_strategy.next_params(current_request.param, response)
-                current_request = current_request.replace(param=next_param)
-            else:
-                current_request = None
-
-    def __aiter__(self) -> "AsyncGenerator[RequestResultT, None]":
-        """返回异步迭代器自身."""
-        return self.paginate()
-
 
 @dataclass
-class RefreshableRequest(Request[RequestResultT], Generic[RequestResultT, ItemT_co]):
+class RefreshableRequest(Request[RequestResultT]):
     """声明了换一批能力的请求描述符."""
 
-    refresh_strategy: RefresherStrategy[Any, RequestResultT, ItemT_co]
+    refresh_strategy: RefresherStrategy[Any, RequestResultT, Any]
 
-    def refresher(self, limit: int | None = None) -> AsyncRefresher[RequestResultT, ItemT_co]:
+    def refresher(self, limit: int | None = None) -> AsyncRefresher[RequestResultT]:
         """返回有状态换一批控制器.
 
         Args:
@@ -245,6 +252,27 @@ class RefreshableRequest(Request[RequestResultT], Generic[RequestResultT, ItemT_
             响应对象列表.
         """
         return [batch async for batch in self.refresh_stream(limit=limit)]
+
+    def next_request(self, previous_response: RequestResultT) -> Self | None:
+        """根据上一次请求的响应, 构建下一次换一批的请求.
+
+        Args:
+            previous_response: 上一次请求得到的响应.
+
+        Returns:
+            下一次请求的描述符, 如果没有更多则返回 None.
+        """
+        if self.refresh_strategy.has_next(self.param, previous_response):
+            next_param = self.refresh_strategy.next_params(self.param, previous_response)
+            return self.replace(param=next_param)
+        return None
+
+
+@dataclass
+class ItemRefreshableRequest(RefreshableRequest[RequestResultT], Generic[RequestResultT, ItemT_co]):
+    """声明了提取数据项能力的换一批请求描述符."""
+
+    refresh_strategy: RefresherStrategy[Any, RequestResultT, ItemT_co]
 
     async def iter_items(self, limit: int | None = None) -> "AsyncGenerator[ItemT_co, None]":
         """跨批展开提取数据项的异步迭代器.
@@ -279,17 +307,3 @@ class RefreshableRequest(Request[RequestResultT], Generic[RequestResultT, ItemT_
             数据项列表.
         """
         return [item async for item in self.iter_items(limit=limit)]
-
-    def next_request(self, previous_response: RequestResultT) -> Self | None:
-        """根据上一次请求的响应, 构建下一次换一批的请求.
-
-        Args:
-            previous_response: 上一次请求得到的响应.
-
-        Returns:
-            下一次请求的描述符, 如果没有更多则返回 None.
-        """
-        if self.refresh_strategy.has_next(self.param, previous_response):
-            next_param = self.refresh_strategy.next_params(self.param, previous_response)
-            return self.replace(param=next_param)
-        return None

--- a/qqmusic_api/core/request.py
+++ b/qqmusic_api/core/request.py
@@ -13,10 +13,8 @@ from typing_extensions import Self, overload
 from ..models.request import Credential
 from .pagination import (
     AsyncPager,
-    AsyncRefresher,
     ItemT_co,
     PagerStrategy,
-    RefresherStrategy,
 )
 from .versioning import Platform
 
@@ -160,20 +158,9 @@ class PaginatedRequest(Request[RequestResultT]):
         Args:
             limit: 最大获取页数.
         """
-        current_request: Request[RequestResultT] | None = self
-        yielded_count = 0
-        while current_request is not None:
-            if limit is not None and yielded_count >= limit:
-                break
-            response = await current_request
+        pager = self.pager(limit=limit)
+        async for response in pager:
             yield response
-            yielded_count += 1
-
-            if self.pager_strategy.has_next(current_request.param, response):
-                next_param = self.pager_strategy.next_params(current_request.param, response)
-                current_request = current_request.replace(param=next_param)
-            else:
-                current_request = None
 
     def __aiter__(self) -> "AsyncGenerator[RequestResultT, None]":
         """返回异步迭代器自身."""
@@ -225,115 +212,6 @@ class ItemPaginatedRequest(PaginatedRequest[RequestResultT], Generic[RequestResu
 
     async def collect_items(self, limit: int | None = None) -> list[ItemT_co]:
         """收集跨页展开的数据项为列表.
-
-        Args:
-            limit: 最大提取条目数量.
-
-        Returns:
-            数据项列表.
-        """
-        return [item async for item in self.iter_items(limit=limit)]
-
-
-@dataclass
-class RefreshableRequest(Request[RequestResultT]):
-    """声明了换一批能力的请求描述符."""
-
-    refresh_strategy: RefresherStrategy[RequestResultT]
-
-    def refresher(self, limit: int | None = None) -> AsyncRefresher[RequestResultT]:
-        """返回有状态换一批控制器.
-
-        Args:
-            limit: 最大换一批次数.
-        """
-        return AsyncRefresher(self, limit=limit)
-
-    async def refresh_stream(self, limit: int | None = None) -> "AsyncGenerator[RequestResultT, None]":
-        """返回换一批响应的异步流式迭代器.
-
-        Args:
-            limit: 最大换一批次数.
-        """
-        refresher = self.refresher(limit=limit)
-        async for batch in refresher:
-            yield batch
-
-    def __aiter__(self) -> "AsyncGenerator[RequestResultT, None]":
-        """返回异步迭代器自身."""
-        return self.refresh_stream()
-
-    async def collect(self, limit: int | None = None) -> list[RequestResultT]:
-        """收集前 limit 次换一批响应数据为列表.
-
-        Args:
-            limit: 最大换一批次数.
-
-        Returns:
-            响应对象列表.
-        """
-        return [batch async for batch in self.refresh_stream(limit=limit)]
-
-    def with_extractor(
-        self, extractor: Callable[[RequestResultT], Iterable[NewItemT] | None]
-    ) -> "ItemRefreshableRequest[RequestResultT, NewItemT]":
-        """显式绑定数据项提取器, 返回支持提取项的换一批请求描述符.
-
-        Args:
-            extractor: 数据项提取函数.
-
-        Returns:
-            具备 iter_items 与 collect_items 能力的 ItemRefreshableRequest.
-        """
-        import dataclasses
-
-        kwargs = {f.name: getattr(self, f.name) for f in dataclasses.fields(RefreshableRequest)}
-        kwargs["items_extractor"] = extractor
-        return ItemRefreshableRequest(**kwargs)
-
-    def next_request(self, previous_response: RequestResultT) -> Self | None:
-        """根据上一次请求的响应, 构建下一次换一批的请求.
-
-        Args:
-            previous_response: 上一次请求得到的响应.
-
-        Returns:
-            下一次请求的描述符, 如果没有更多则返回 None.
-        """
-        if self.refresh_strategy.has_next(self.param, previous_response):
-            next_param = self.refresh_strategy.next_params(self.param, previous_response)
-            return self.replace(param=next_param)
-        return None
-
-
-@dataclass
-class ItemRefreshableRequest(RefreshableRequest[RequestResultT], Generic[RequestResultT, ItemT_co]):
-    """声明了提取数据项能力的换一批请求描述符."""
-
-    items_extractor: Callable[[RequestResultT], Iterable[ItemT_co] | None]
-
-    async def iter_items(self, limit: int | None = None) -> "AsyncGenerator[ItemT_co, None]":
-        """跨批展开提取数据项的异步迭代器.
-
-        Args:
-            limit: 最大提取条目数量.
-
-        Yields:
-            数据项实体.
-        """
-        count = 0
-        async for batch in self.refresh_stream():
-            items = self.items_extractor(batch)
-            if items is None:
-                continue
-            for item in items:
-                if limit is not None and count >= limit:
-                    return
-                yield item
-                count += 1
-
-    async def collect_items(self, limit: int | None = None) -> list[ItemT_co]:
-        """收集跨批展开的数据项为列表.
 
         Args:
             limit: 最大提取条目数量.

--- a/qqmusic_api/core/request.py
+++ b/qqmusic_api/core/request.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from typing_extensions import Self, overload
 
 from ..models.request import Credential
-from .pagination import AsyncPager, AsyncRefresher, PagerStrategy, RefresherStrategy
+from .pagination import AsyncPager, AsyncRefresher, ItemT_co, PagerStrategy, RefresherStrategy
 from .versioning import Platform
 
 if TYPE_CHECKING:
@@ -109,12 +109,12 @@ class Request(Generic[RequestResultT]):
 
 
 @dataclass
-class PaginatedRequest(Request[RequestResultT]):
+class PaginatedRequest(Request[RequestResultT], Generic[RequestResultT, ItemT_co]):
     """声明了连续翻页能力的请求描述符."""
 
-    pager_strategy: PagerStrategy[Any, RequestResultT]
+    pager_strategy: PagerStrategy[Any, RequestResultT, ItemT_co]
 
-    def next_request(self, previous_response: RequestResultT) -> "PaginatedRequest[RequestResultT] | None":
+    def next_request(self, previous_response: RequestResultT) -> "PaginatedRequest[RequestResultT, ItemT_co] | None":
         """根据上一次请求的响应, 构建下一次翻页的请求.
 
         Args:
@@ -128,7 +128,7 @@ class PaginatedRequest(Request[RequestResultT]):
             return self.replace(param=next_param)
         return None
 
-    def pager(self, limit: int | None = None) -> AsyncPager[RequestResultT]:
+    def pager(self, limit: int | None = None) -> AsyncPager[RequestResultT, ItemT_co]:
         """返回有状态异步分页器.
 
         Args:
@@ -147,7 +147,7 @@ class PaginatedRequest(Request[RequestResultT]):
         """
         return [response async for response in self.paginate(limit=limit)]
 
-    async def iter_items(self, limit: int | None = None) -> "AsyncGenerator[Any, None]":
+    async def iter_items(self, limit: int | None = None) -> "AsyncGenerator[ItemT_co, None]":
         """跨页展开提取数据项的异步迭代器.
 
         Args:
@@ -170,7 +170,7 @@ class PaginatedRequest(Request[RequestResultT]):
                 yield item
                 count += 1
 
-    async def collect_items(self, limit: int | None = None) -> list[Any]:
+    async def collect_items(self, limit: int | None = None) -> list[ItemT_co]:
         """收集跨页展开的数据项为列表.
 
         Args:
@@ -208,12 +208,12 @@ class PaginatedRequest(Request[RequestResultT]):
 
 
 @dataclass
-class RefreshableRequest(Request[RequestResultT]):
+class RefreshableRequest(Request[RequestResultT], Generic[RequestResultT, ItemT_co]):
     """声明了换一批能力的请求描述符."""
 
-    refresh_strategy: RefresherStrategy[Any, RequestResultT]
+    refresh_strategy: RefresherStrategy[Any, RequestResultT, ItemT_co]
 
-    def refresher(self, limit: int | None = None) -> AsyncRefresher[RequestResultT]:
+    def refresher(self, limit: int | None = None) -> AsyncRefresher[RequestResultT, ItemT_co]:
         """返回有状态换一批控制器.
 
         Args:
@@ -246,7 +246,7 @@ class RefreshableRequest(Request[RequestResultT]):
         """
         return [batch async for batch in self.refresh_stream(limit=limit)]
 
-    async def iter_items(self, limit: int | None = None) -> "AsyncGenerator[Any, None]":
+    async def iter_items(self, limit: int | None = None) -> "AsyncGenerator[ItemT_co, None]":
         """跨批展开提取数据项的异步迭代器.
 
         Args:
@@ -269,7 +269,7 @@ class RefreshableRequest(Request[RequestResultT]):
                 yield item
                 count += 1
 
-    async def collect_items(self, limit: int | None = None) -> list[Any]:
+    async def collect_items(self, limit: int | None = None) -> list[ItemT_co]:
         """收集跨批展开的数据项为列表.
 
         Args:

--- a/qqmusic_api/core/request.py
+++ b/qqmusic_api/core/request.py
@@ -14,7 +14,6 @@ from ..models.request import Credential
 from .pagination import (
     AsyncPager,
     AsyncRefresher,
-    ExtractorWrapperStrategy,
     ItemT_co,
     PagerStrategy,
     RefresherStrategy,
@@ -73,7 +72,7 @@ class Request(Generic[RequestResultT]):
     _client: "Client"
     module: str
     method: str
-    param: dict[str, Any] | dict[int, Any]
+    param: dict[str, Any]
     response_model: type[BaseModel] | None = None
     comm: dict[str, int | str | bool] | None = None
     override_comm: bool = False
@@ -120,7 +119,7 @@ class Request(Generic[RequestResultT]):
 class PaginatedRequest(Request[RequestResultT]):
     """声明了连续翻页能力的请求描述符."""
 
-    pager_strategy: PagerStrategy[Any, RequestResultT, Any]
+    pager_strategy: PagerStrategy[RequestResultT]
 
     def next_request(self, previous_response: RequestResultT) -> Self | None:
         """根据上一次请求的响应, 构建下一次翻页的请求.
@@ -191,13 +190,10 @@ class PaginatedRequest(Request[RequestResultT]):
         Returns:
             具备 iter_items 与 collect_items 能力的 ItemPaginatedRequest.
         """
-        new_strategy = ExtractorWrapperStrategy(self.pager_strategy, extractor)
         import dataclasses
 
-        kwargs = {
-            f.name: getattr(self, f.name) for f in dataclasses.fields(PaginatedRequest) if f.name != "pager_strategy"
-        }
-        kwargs["pager_strategy"] = new_strategy
+        kwargs = {f.name: getattr(self, f.name) for f in dataclasses.fields(PaginatedRequest)}
+        kwargs["items_extractor"] = extractor
         return ItemPaginatedRequest(**kwargs)
 
 
@@ -205,7 +201,7 @@ class PaginatedRequest(Request[RequestResultT]):
 class ItemPaginatedRequest(PaginatedRequest[RequestResultT], Generic[RequestResultT, ItemT_co]):
     """声明了提取数据项能力的连续翻页请求描述符."""
 
-    pager_strategy: PagerStrategy[Any, RequestResultT, ItemT_co]
+    items_extractor: Callable[[RequestResultT], Iterable[ItemT_co] | None]
 
     async def iter_items(self, limit: int | None = None) -> "AsyncGenerator[ItemT_co, None]":
         """跨页展开提取数据项的异步迭代器.
@@ -215,15 +211,12 @@ class ItemPaginatedRequest(PaginatedRequest[RequestResultT], Generic[RequestResu
 
         Yields:
             数据项实体.
-
-        Raises:
-            TypeError: 当策略未配置 items_extractor 时抛出.
         """
         count = 0
         async for response in self.paginate():
-            items = self.pager_strategy.get_items(response)
+            items = self.items_extractor(response)
             if items is None:
-                raise TypeError("当前分页请求的策略未配置 items_extractor, 无法使用 iter_items()")
+                continue
             for item in items:
                 if limit is not None and count >= limit:
                     return
@@ -246,7 +239,7 @@ class ItemPaginatedRequest(PaginatedRequest[RequestResultT], Generic[RequestResu
 class RefreshableRequest(Request[RequestResultT]):
     """声明了换一批能力的请求描述符."""
 
-    refresh_strategy: RefresherStrategy[Any, RequestResultT, Any]
+    refresh_strategy: RefresherStrategy[RequestResultT]
 
     def refresher(self, limit: int | None = None) -> AsyncRefresher[RequestResultT]:
         """返回有状态换一批控制器.
@@ -292,15 +285,10 @@ class RefreshableRequest(Request[RequestResultT]):
         Returns:
             具备 iter_items 与 collect_items 能力的 ItemRefreshableRequest.
         """
-        new_strategy = ExtractorWrapperStrategy(self.refresh_strategy, extractor)
         import dataclasses
 
-        kwargs = {
-            f.name: getattr(self, f.name)
-            for f in dataclasses.fields(RefreshableRequest)
-            if f.name != "refresh_strategy"
-        }
-        kwargs["refresh_strategy"] = new_strategy
+        kwargs = {f.name: getattr(self, f.name) for f in dataclasses.fields(RefreshableRequest)}
+        kwargs["items_extractor"] = extractor
         return ItemRefreshableRequest(**kwargs)
 
     def next_request(self, previous_response: RequestResultT) -> Self | None:
@@ -322,7 +310,7 @@ class RefreshableRequest(Request[RequestResultT]):
 class ItemRefreshableRequest(RefreshableRequest[RequestResultT], Generic[RequestResultT, ItemT_co]):
     """声明了提取数据项能力的换一批请求描述符."""
 
-    refresh_strategy: RefresherStrategy[Any, RequestResultT, ItemT_co]
+    items_extractor: Callable[[RequestResultT], Iterable[ItemT_co] | None]
 
     async def iter_items(self, limit: int | None = None) -> "AsyncGenerator[ItemT_co, None]":
         """跨批展开提取数据项的异步迭代器.
@@ -332,15 +320,12 @@ class ItemRefreshableRequest(RefreshableRequest[RequestResultT], Generic[Request
 
         Yields:
             数据项实体.
-
-        Raises:
-            TypeError: 当策略未配置 items_extractor 时抛出.
         """
         count = 0
         async for batch in self.refresh_stream():
-            items = self.refresh_strategy.get_items(batch)
+            items = self.items_extractor(batch)
             if items is None:
-                raise TypeError("当前换一批请求的策略未配置 items_extractor, 无法使用 iter_items()")
+                continue
             for item in items:
                 if limit is not None and count >= limit:
                     return

--- a/qqmusic_api/core/request.py
+++ b/qqmusic_api/core/request.py
@@ -8,16 +8,18 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
 from pydantic import BaseModel
-from typing_extensions import overload
+from typing_extensions import Self, overload
 
 from ..models.request import Credential
-from .pagination import PagerMeta, RefreshMeta, RequestResultT, ResponsePager, ResponseRefresher
+from .pagination import PagerStrategy, RefresherStrategy
 from .versioning import Platform
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
     from .client import Client
 
-
+RequestResultT = TypeVar("RequestResultT", bound=BaseModel | dict[str, Any])
 ResponseModel = TypeVar("ResponseModel", bound=BaseModel)
 AllowErrorCodes = Literal["all"] | set[int] | frozenset[int] | tuple[int, ...]
 
@@ -95,7 +97,7 @@ class Request(Generic[RequestResultT]):
         comm_items = tuple(sorted(self.comm.items(), key=lambda item: item[0])) if self.comm is not None else None
         return (platform, comm_items, self.override_comm, credential_key, self.sign)
 
-    def replace(self, **changes: Any) -> "Request[RequestResultT]":
+    def replace(self, **changes: Any) -> Self:
         """返回一个应用了修改的新 Request 对象, 不会修改原对象."""
         if "param" not in changes:
             changes["param"] = copy.deepcopy(self.param)
@@ -110,31 +112,50 @@ class Request(Generic[RequestResultT]):
 class PaginatedRequest(Request[RequestResultT]):
     """声明了连续翻页能力的请求描述符."""
 
-    pager_meta: PagerMeta
+    pager_strategy: PagerStrategy[Any, RequestResultT]
 
-    def get_pager_meta(self) -> PagerMeta:
-        """返回连续翻页元数据."""
-        return self.pager_meta
-
-    def paginate(self, limit: int | None = None) -> ResponsePager[RequestResultT]:
+    async def paginate(self, limit: int | None = None) -> "AsyncGenerator[RequestResultT, None]":
         """返回响应的分页迭代器.
 
         Args:
             limit: 最大获取页数.
         """
-        return ResponsePager(self, limit=limit)
+        current_request: Request[RequestResultT] | None = self
+        yielded_count = 0
+        while current_request is not None:
+            if limit is not None and yielded_count >= limit:
+                break
+            response = await current_request
+            yield response
+            yielded_count += 1
+
+            if self.pager_strategy.has_next(current_request.param, response):
+                next_param = self.pager_strategy.next_params(current_request.param, response)
+                current_request = current_request.replace(param=next_param)
+            else:
+                current_request = None
+
+    def __aiter__(self) -> "AsyncGenerator[RequestResultT, None]":
+        """返回异步迭代器自身."""
+        return self.paginate()
 
 
 @dataclass
 class RefreshableRequest(Request[RequestResultT]):
     """声明了换一批能力的请求描述符."""
 
-    refresh_meta: RefreshMeta
+    refresh_strategy: RefresherStrategy[Any, RequestResultT]
 
-    def get_refresh_meta(self) -> RefreshMeta:
-        """返回换一批元数据."""
-        return self.refresh_meta
+    def next_request(self, previous_response: RequestResultT) -> "RefreshableRequest[RequestResultT] | None":
+        """根据上一次请求的响应, 构建下一次换一批的请求.
 
-    def refresh(self) -> ResponseRefresher[RequestResultT]:
-        """返回响应的换一批控制器."""
-        return ResponseRefresher(self)
+        Args:
+            previous_response: 上一次请求得到的响应.
+
+        Returns:
+            下一次请求的描述符, 如果没有更多则返回 None.
+        """
+        if self.refresh_strategy.has_next(self.param, previous_response):
+            next_param = self.refresh_strategy.next_params(self.param, previous_response)
+            return self.replace(param=next_param)
+        return None

--- a/qqmusic_api/core/request.py
+++ b/qqmusic_api/core/request.py
@@ -2,7 +2,7 @@
 
 import copy
 from collections.abc import Callable, Generator, Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from dataclasses import replace as dc_replace
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
@@ -177,9 +177,7 @@ class PaginatedRequest(Request[RequestResultT]):
         Returns:
             具备 iter_items 与 collect_items 能力的 ItemPaginatedRequest.
         """
-        import dataclasses
-
-        kwargs = {f.name: getattr(self, f.name) for f in dataclasses.fields(PaginatedRequest)}
+        kwargs = {f.name: getattr(self, f.name) for f in fields(PaginatedRequest)}
         kwargs["items_extractor"] = extractor
         return ItemPaginatedRequest(**kwargs)
 

--- a/qqmusic_api/core/request.py
+++ b/qqmusic_api/core/request.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from typing_extensions import Self, overload
 
 from ..models.request import Credential
-from .pagination import PagerStrategy, RefresherStrategy
+from .pagination import AsyncPager, AsyncRefresher, PagerStrategy, RefresherStrategy
 from .versioning import Platform
 
 if TYPE_CHECKING:
@@ -114,6 +114,73 @@ class PaginatedRequest(Request[RequestResultT]):
 
     pager_strategy: PagerStrategy[Any, RequestResultT]
 
+    def next_request(self, previous_response: RequestResultT) -> "PaginatedRequest[RequestResultT] | None":
+        """根据上一次请求的响应, 构建下一次翻页的请求.
+
+        Args:
+            previous_response: 上一次请求得到的响应.
+
+        Returns:
+            下一次请求的描述符, 如果没有更多则返回 None.
+        """
+        if self.pager_strategy.has_next(self.param, previous_response):
+            next_param = self.pager_strategy.next_params(self.param, previous_response)
+            return self.replace(param=next_param)
+        return None
+
+    def pager(self, limit: int | None = None) -> AsyncPager[RequestResultT]:
+        """返回有状态异步分页器.
+
+        Args:
+            limit: 最大获取页数.
+        """
+        return AsyncPager(self, limit=limit)
+
+    async def collect(self, limit: int | None = None) -> list[RequestResultT]:
+        """收集前 limit 页响应数据为列表.
+
+        Args:
+            limit: 最大获取页数.
+
+        Returns:
+            响应对象列表.
+        """
+        return [response async for response in self.paginate(limit=limit)]
+
+    async def iter_items(self, limit: int | None = None) -> "AsyncGenerator[Any, None]":
+        """跨页展开提取数据项的异步迭代器.
+
+        Args:
+            limit: 最大提取条目数量.
+
+        Yields:
+            数据项实体.
+
+        Raises:
+            TypeError: 当策略未配置 items_extractor 时抛出.
+        """
+        count = 0
+        async for response in self.paginate():
+            items = self.pager_strategy.get_items(response)
+            if items is None:
+                raise TypeError("当前分页请求的策略未配置 items_extractor, 无法使用 iter_items()")
+            for item in items:
+                if limit is not None and count >= limit:
+                    return
+                yield item
+                count += 1
+
+    async def collect_items(self, limit: int | None = None) -> list[Any]:
+        """收集跨页展开的数据项为列表.
+
+        Args:
+            limit: 最大提取条目数量.
+
+        Returns:
+            数据项列表.
+        """
+        return [item async for item in self.iter_items(limit=limit)]
+
     async def paginate(self, limit: int | None = None) -> "AsyncGenerator[RequestResultT, None]":
         """返回响应的分页迭代器.
 
@@ -145,6 +212,73 @@ class RefreshableRequest(Request[RequestResultT]):
     """声明了换一批能力的请求描述符."""
 
     refresh_strategy: RefresherStrategy[Any, RequestResultT]
+
+    def refresher(self, limit: int | None = None) -> AsyncRefresher[RequestResultT]:
+        """返回有状态换一批控制器.
+
+        Args:
+            limit: 最大换一批次数.
+        """
+        return AsyncRefresher(self, limit=limit)
+
+    async def refresh_stream(self, limit: int | None = None) -> "AsyncGenerator[RequestResultT, None]":
+        """返回换一批响应的异步流式迭代器.
+
+        Args:
+            limit: 最大换一批次数.
+        """
+        refresher = self.refresher(limit=limit)
+        async for batch in refresher:
+            yield batch
+
+    def __aiter__(self) -> "AsyncGenerator[RequestResultT, None]":
+        """返回异步迭代器自身."""
+        return self.refresh_stream()
+
+    async def collect(self, limit: int | None = None) -> list[RequestResultT]:
+        """收集前 limit 次换一批响应数据为列表.
+
+        Args:
+            limit: 最大换一批次数.
+
+        Returns:
+            响应对象列表.
+        """
+        return [batch async for batch in self.refresh_stream(limit=limit)]
+
+    async def iter_items(self, limit: int | None = None) -> "AsyncGenerator[Any, None]":
+        """跨批展开提取数据项的异步迭代器.
+
+        Args:
+            limit: 最大提取条目数量.
+
+        Yields:
+            数据项实体.
+
+        Raises:
+            TypeError: 当策略未配置 items_extractor 时抛出.
+        """
+        count = 0
+        async for batch in self.refresh_stream():
+            items = self.refresh_strategy.get_items(batch)
+            if items is None:
+                raise TypeError("当前换一批请求的策略未配置 items_extractor, 无法使用 iter_items()")
+            for item in items:
+                if limit is not None and count >= limit:
+                    return
+                yield item
+                count += 1
+
+    async def collect_items(self, limit: int | None = None) -> list[Any]:
+        """收集跨批展开的数据项为列表.
+
+        Args:
+            limit: 最大提取条目数量.
+
+        Returns:
+            数据项列表.
+        """
+        return [item async for item in self.iter_items(limit=limit)]
 
     def next_request(self, previous_response: RequestResultT) -> "RefreshableRequest[RequestResultT] | None":
         """根据上一次请求的响应, 构建下一次换一批的请求.

--- a/qqmusic_api/core/request.py
+++ b/qqmusic_api/core/request.py
@@ -27,8 +27,8 @@ AllowErrorCodes = Literal["all"] | set[int] | frozenset[int] | tuple[int, ...]
 @overload
 def _build_result(
     raw: dict[str, Any],
-    response_model: type["ResponseModel"],
-) -> "ResponseModel": ...
+    response_model: type[ResponseModel],
+) -> ResponseModel: ...
 
 
 @overload
@@ -114,7 +114,7 @@ class PaginatedRequest(Request[RequestResultT], Generic[RequestResultT, ItemT_co
 
     pager_strategy: PagerStrategy[Any, RequestResultT, ItemT_co]
 
-    def next_request(self, previous_response: RequestResultT) -> "PaginatedRequest[RequestResultT, ItemT_co] | None":
+    def next_request(self, previous_response: RequestResultT) -> Self | None:
         """根据上一次请求的响应, 构建下一次翻页的请求.
 
         Args:
@@ -280,7 +280,7 @@ class RefreshableRequest(Request[RequestResultT], Generic[RequestResultT, ItemT_
         """
         return [item async for item in self.iter_items(limit=limit)]
 
-    def next_request(self, previous_response: RequestResultT) -> "RefreshableRequest[RequestResultT] | None":
+    def next_request(self, previous_response: RequestResultT) -> Self | None:
         """根据上一次请求的响应, 构建下一次换一批的请求.
 
         Args:

--- a/qqmusic_api/core/request.py
+++ b/qqmusic_api/core/request.py
@@ -1,7 +1,7 @@
 """请求描述符与批量请求容器. 提供对 API 请求的抽象与调度."""
 
 import copy
-from collections.abc import Generator
+from collections.abc import Callable, Generator, Iterable
 from dataclasses import dataclass
 from dataclasses import replace as dc_replace
 from functools import cached_property
@@ -11,7 +11,14 @@ from pydantic import BaseModel
 from typing_extensions import Self, overload
 
 from ..models.request import Credential
-from .pagination import AsyncPager, AsyncRefresher, ItemT_co, PagerStrategy, RefresherStrategy
+from .pagination import (
+    AsyncPager,
+    AsyncRefresher,
+    ExtractorWrapperStrategy,
+    ItemT_co,
+    PagerStrategy,
+    RefresherStrategy,
+)
 from .versioning import Platform
 
 if TYPE_CHECKING:
@@ -21,6 +28,7 @@ if TYPE_CHECKING:
 
 RequestResultT = TypeVar("RequestResultT", bound=BaseModel | dict[str, Any])
 ResponseModel = TypeVar("ResponseModel", bound=BaseModel)
+NewItemT = TypeVar("NewItemT")
 AllowErrorCodes = Literal["all"] | set[int] | frozenset[int] | tuple[int, ...]
 
 
@@ -172,6 +180,26 @@ class PaginatedRequest(Request[RequestResultT]):
         """返回异步迭代器自身."""
         return self.paginate()
 
+    def with_extractor(
+        self, extractor: Callable[[RequestResultT], Iterable[NewItemT] | None]
+    ) -> "ItemPaginatedRequest[RequestResultT, NewItemT]":
+        """显式绑定数据项提取器, 返回支持提取项的连续翻页请求描述符.
+
+        Args:
+            extractor: 数据项提取函数.
+
+        Returns:
+            具备 iter_items 与 collect_items 能力的 ItemPaginatedRequest.
+        """
+        new_strategy = ExtractorWrapperStrategy(self.pager_strategy, extractor)
+        import dataclasses
+
+        kwargs = {
+            f.name: getattr(self, f.name) for f in dataclasses.fields(PaginatedRequest) if f.name != "pager_strategy"
+        }
+        kwargs["pager_strategy"] = new_strategy
+        return ItemPaginatedRequest(**kwargs)
+
 
 @dataclass
 class ItemPaginatedRequest(PaginatedRequest[RequestResultT], Generic[RequestResultT, ItemT_co]):
@@ -252,6 +280,28 @@ class RefreshableRequest(Request[RequestResultT]):
             响应对象列表.
         """
         return [batch async for batch in self.refresh_stream(limit=limit)]
+
+    def with_extractor(
+        self, extractor: Callable[[RequestResultT], Iterable[NewItemT] | None]
+    ) -> "ItemRefreshableRequest[RequestResultT, NewItemT]":
+        """显式绑定数据项提取器, 返回支持提取项的换一批请求描述符.
+
+        Args:
+            extractor: 数据项提取函数.
+
+        Returns:
+            具备 iter_items 与 collect_items 能力的 ItemRefreshableRequest.
+        """
+        new_strategy = ExtractorWrapperStrategy(self.refresh_strategy, extractor)
+        import dataclasses
+
+        kwargs = {
+            f.name: getattr(self, f.name)
+            for f in dataclasses.fields(RefreshableRequest)
+            if f.name != "refresh_strategy"
+        }
+        kwargs["refresh_strategy"] = new_strategy
+        return ItemRefreshableRequest(**kwargs)
 
     def next_request(self, previous_response: RequestResultT) -> Self | None:
         """根据上一次请求的响应, 构建下一次换一批的请求.

--- a/qqmusic_api/modules/_base.py
+++ b/qqmusic_api/modules/_base.py
@@ -3,12 +3,12 @@
 from typing import TYPE_CHECKING, Any, overload
 
 from ..core.exceptions import CredentialInvalidError
+from ..core.pagination import PagerStrategy, RefresherStrategy
+from ..core.request import AllowErrorCodes, PaginatedRequest, RefreshableRequest, Request, ResponseModel
 from ..core.versioning import Platform
 
 if TYPE_CHECKING:
     from ..core.client import Client
-    from ..core.pagination import PagerMeta, RefreshMeta
-    from ..core.request import AllowErrorCodes, PaginatedRequest, RefreshableRequest, Request, ResponseModel
     from ..models.request import Credential
 
 
@@ -86,13 +86,13 @@ class ApiModule:
         preserve_bool: bool = False,
         credential: "Credential | None" = None,
         platform: Platform | None = None,
-        allow_error_codes: "AllowErrorCodes | None" = None,
+        allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
-        pager_meta: None = None,
-        refresh_meta: None = None,
+        pager_strategy: None = None,
+        refresh_strategy: None = None,
         sign: bool = False,
         require_login: bool = False,
-    ) -> "Request[dict[str, Any]]": ...
+    ) -> Request[dict[str, Any]]: ...
 
     @overload
     def _build_request(
@@ -107,13 +107,13 @@ class ApiModule:
         preserve_bool: bool = False,
         credential: "Credential | None" = None,
         platform: Platform | None = None,
-        allow_error_codes: "AllowErrorCodes | None" = None,
+        allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
-        pager_meta: "PagerMeta",
-        refresh_meta: None = None,
+        pager_strategy: PagerStrategy[Any, dict[str, Any]],
+        refresh_strategy: None = None,
         sign: bool = False,
         require_login: bool = False,
-    ) -> "PaginatedRequest[dict[str, Any]]": ...
+    ) -> PaginatedRequest[dict[str, Any]]: ...
 
     @overload
     def _build_request(
@@ -128,13 +128,13 @@ class ApiModule:
         preserve_bool: bool = False,
         credential: "Credential | None" = None,
         platform: Platform | None = None,
-        allow_error_codes: "AllowErrorCodes | None" = None,
+        allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
-        pager_meta: None = None,
-        refresh_meta: "RefreshMeta",
+        pager_strategy: None = None,
+        refresh_strategy: RefresherStrategy[Any, dict[str, Any]],
         sign: bool = False,
         require_login: bool = False,
-    ) -> "RefreshableRequest[dict[str, Any]]": ...
+    ) -> RefreshableRequest[dict[str, Any]]: ...
 
     @overload
     def _build_request(
@@ -142,20 +142,20 @@ class ApiModule:
         module: str,
         method: str,
         param: dict[str, Any] | dict[int, Any],
-        response_model: type["ResponseModel"],
+        response_model: type[ResponseModel],
         comm: dict[str, Any] | None = None,
         *,
         override_comm: bool = False,
         preserve_bool: bool = False,
         credential: "Credential | None" = None,
         platform: Platform | None = None,
-        allow_error_codes: "AllowErrorCodes | None" = None,
+        allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
-        pager_meta: None = None,
-        refresh_meta: None = None,
+        pager_strategy: None = None,
+        refresh_strategy: None = None,
         sign: bool = False,
         require_login: bool = False,
-    ) -> "Request[ResponseModel]": ...
+    ) -> Request[ResponseModel]: ...
 
     @overload
     def _build_request(
@@ -163,20 +163,20 @@ class ApiModule:
         module: str,
         method: str,
         param: dict[str, Any] | dict[int, Any],
-        response_model: type["ResponseModel"],
+        response_model: type[ResponseModel],
         comm: dict[str, Any] | None = None,
         *,
         override_comm: bool = False,
         preserve_bool: bool = False,
         credential: "Credential | None" = None,
         platform: Platform | None = None,
-        allow_error_codes: "AllowErrorCodes | None" = None,
+        allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
-        pager_meta: "PagerMeta",
-        refresh_meta: None = None,
+        pager_strategy: PagerStrategy[Any, ResponseModel],
+        refresh_strategy: None = None,
         sign: bool = False,
         require_login: bool = False,
-    ) -> "PaginatedRequest[ResponseModel]": ...
+    ) -> PaginatedRequest[ResponseModel]: ...
 
     @overload
     def _build_request(
@@ -184,40 +184,40 @@ class ApiModule:
         module: str,
         method: str,
         param: dict[str, Any] | dict[int, Any],
-        response_model: type["ResponseModel"],
+        response_model: type[ResponseModel],
         comm: dict[str, Any] | None = None,
         *,
         override_comm: bool = False,
         preserve_bool: bool = False,
         credential: "Credential | None" = None,
         platform: Platform | None = None,
-        allow_error_codes: "AllowErrorCodes | None" = None,
+        allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
-        pager_meta: None = None,
-        refresh_meta: "RefreshMeta",
+        pager_strategy: None = None,
+        refresh_strategy: RefresherStrategy[Any, ResponseModel],
         sign: bool = False,
         require_login: bool = False,
-    ) -> "RefreshableRequest[ResponseModel]": ...
+    ) -> RefreshableRequest[ResponseModel]: ...
 
     def _build_request(
         self,
         module: str,
         method: str,
         param: dict[str, Any] | dict[int, Any],
-        response_model: type["ResponseModel"] | None = None,
+        response_model: type[ResponseModel] | None = None,
         comm: dict[str, Any] | None = None,
         *,
         override_comm: bool = False,
         preserve_bool: bool = False,
         credential: "Credential | None" = None,
         platform: Platform | None = None,
-        allow_error_codes: "AllowErrorCodes | None" = None,
+        allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
-        pager_meta: "PagerMeta | None" = None,
-        refresh_meta: "RefreshMeta | None" = None,
+        pager_strategy: PagerStrategy | None = None,
+        refresh_strategy: RefresherStrategy | None = None,
         sign: bool = False,
         require_login: bool = False,
-    ) -> "Request[Any] | PaginatedRequest[Any] | RefreshableRequest[Any]":
+    ) -> Request[Any] | PaginatedRequest[Any] | RefreshableRequest[Any]:
         """构建可 await 的请求描述符.
 
         Args:
@@ -232,8 +232,8 @@ class ApiModule:
             platform: 本次请求的平台标识. 默认使用客户端所属平台.
             allow_error_codes: 允许放行的业务非零错误码.
             parse_on_allow: 为 True 时, 匹配 `allow_error_codes` 的响应仍走模型解析而非返回原始字典.
-            pager_meta: 分页组件元数据. 提供后则升级为 `PaginatedRequest`.
-            refresh_meta: 刷新组件元数据. 提供后则升级为 `RefreshableRequest`.
+            pager_strategy: 分页策略描述符. 提供后则升级为 `PaginatedRequest`.
+            refresh_strategy: 换一批策略描述符. 提供后则升级为 `RefreshableRequest`.
             sign: 是否对请求进行签名.
             require_login: 为 True 时, 在构建请求前校验凭证有效性.
 
@@ -241,13 +241,13 @@ class ApiModule:
             组装好的 Request 或衍生子类描述符.
 
         Raises:
-            ValueError: 如果同时提供 pager_meta 和 refresh_meta 时抛出.
+            ValueError: 如果同时提供 pager_strategy 和 refresh_strategy 时抛出.
             CredentialInvalidError: 如果 require_login 为 True 且凭证无效时抛出.
         """
         from ..core.request import PaginatedRequest, RefreshableRequest, Request
 
-        if pager_meta is not None and refresh_meta is not None:
-            raise ValueError("pager_meta 与 refresh_meta 不能同时声明")
+        if pager_strategy is not None and refresh_strategy is not None:
+            raise ValueError("pager_strategy 与 refresh_strategy 不能同时声明")
 
         if require_login:
             credential = self._require_login(credential)
@@ -267,8 +267,8 @@ class ApiModule:
             "parse_on_allow": parse_on_allow,
             "sign": sign,
         }
-        if pager_meta is not None:
-            return PaginatedRequest(**common_kwargs, pager_meta=pager_meta)
-        if refresh_meta is not None:
-            return RefreshableRequest(**common_kwargs, refresh_meta=refresh_meta)
+        if pager_strategy is not None:
+            return PaginatedRequest(**common_kwargs, pager_strategy=pager_strategy)
+        if refresh_strategy is not None:
+            return RefreshableRequest(**common_kwargs, refresh_strategy=refresh_strategy)
         return Request(**common_kwargs)

--- a/qqmusic_api/modules/_base.py
+++ b/qqmusic_api/modules/_base.py
@@ -3,7 +3,7 @@
 from typing import TYPE_CHECKING, Any, overload
 
 from ..core.exceptions import CredentialInvalidError
-from ..core.pagination import PagerStrategy, RefresherStrategy
+from ..core.pagination import ItemT_co, PagerStrategy, RefresherStrategy
 from ..core.request import AllowErrorCodes, PaginatedRequest, RefreshableRequest, Request, ResponseModel
 from ..core.versioning import Platform
 
@@ -109,11 +109,11 @@ class ApiModule:
         platform: Platform | None = None,
         allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
-        pager_strategy: PagerStrategy[Any, dict[str, Any]],
+        pager_strategy: PagerStrategy[Any, dict[str, Any], ItemT_co],
         refresh_strategy: None = None,
         sign: bool = False,
         require_login: bool = False,
-    ) -> PaginatedRequest[dict[str, Any]]: ...
+    ) -> PaginatedRequest[dict[str, Any], ItemT_co]: ...
 
     @overload
     def _build_request(
@@ -131,10 +131,10 @@ class ApiModule:
         allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
         pager_strategy: None = None,
-        refresh_strategy: RefresherStrategy[Any, dict[str, Any]],
+        refresh_strategy: RefresherStrategy[Any, dict[str, Any], ItemT_co],
         sign: bool = False,
         require_login: bool = False,
-    ) -> RefreshableRequest[dict[str, Any]]: ...
+    ) -> RefreshableRequest[dict[str, Any], ItemT_co]: ...
 
     @overload
     def _build_request(
@@ -172,11 +172,11 @@ class ApiModule:
         platform: Platform | None = None,
         allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
-        pager_strategy: PagerStrategy[Any, ResponseModel],
+        pager_strategy: PagerStrategy[Any, ResponseModel, ItemT_co],
         refresh_strategy: None = None,
         sign: bool = False,
         require_login: bool = False,
-    ) -> PaginatedRequest[ResponseModel]: ...
+    ) -> PaginatedRequest[ResponseModel, ItemT_co]: ...
 
     @overload
     def _build_request(
@@ -194,10 +194,10 @@ class ApiModule:
         allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
         pager_strategy: None = None,
-        refresh_strategy: RefresherStrategy[Any, ResponseModel],
+        refresh_strategy: RefresherStrategy[Any, ResponseModel, ItemT_co],
         sign: bool = False,
         require_login: bool = False,
-    ) -> RefreshableRequest[ResponseModel]: ...
+    ) -> RefreshableRequest[ResponseModel, ItemT_co]: ...
 
     def _build_request(
         self,

--- a/qqmusic_api/modules/_base.py
+++ b/qqmusic_api/modules/_base.py
@@ -4,7 +4,13 @@ from typing import TYPE_CHECKING, Any, overload
 
 from ..core.exceptions import CredentialInvalidError
 from ..core.pagination import ItemT_co, PagerStrategy, RefresherStrategy
-from ..core.request import AllowErrorCodes, PaginatedRequest, RefreshableRequest, Request, ResponseModel
+from ..core.request import (
+    AllowErrorCodes,
+    ItemPaginatedRequest,
+    ItemRefreshableRequest,
+    Request,
+    ResponseModel,
+)
 from ..core.versioning import Platform
 
 if TYPE_CHECKING:
@@ -113,7 +119,7 @@ class ApiModule:
         refresh_strategy: None = None,
         sign: bool = False,
         require_login: bool = False,
-    ) -> PaginatedRequest[dict[str, Any], ItemT_co]: ...
+    ) -> ItemPaginatedRequest[dict[str, Any], ItemT_co]: ...
 
     @overload
     def _build_request(
@@ -134,7 +140,7 @@ class ApiModule:
         refresh_strategy: RefresherStrategy[Any, dict[str, Any], ItemT_co],
         sign: bool = False,
         require_login: bool = False,
-    ) -> RefreshableRequest[dict[str, Any], ItemT_co]: ...
+    ) -> ItemRefreshableRequest[dict[str, Any], ItemT_co]: ...
 
     @overload
     def _build_request(
@@ -176,7 +182,7 @@ class ApiModule:
         refresh_strategy: None = None,
         sign: bool = False,
         require_login: bool = False,
-    ) -> PaginatedRequest[ResponseModel, ItemT_co]: ...
+    ) -> ItemPaginatedRequest[ResponseModel, ItemT_co]: ...
 
     @overload
     def _build_request(
@@ -197,7 +203,7 @@ class ApiModule:
         refresh_strategy: RefresherStrategy[Any, ResponseModel, ItemT_co],
         sign: bool = False,
         require_login: bool = False,
-    ) -> RefreshableRequest[ResponseModel, ItemT_co]: ...
+    ) -> ItemRefreshableRequest[ResponseModel, ItemT_co]: ...
 
     def _build_request(
         self,
@@ -217,7 +223,7 @@ class ApiModule:
         refresh_strategy: RefresherStrategy[Any, Any, Any] | None = None,
         sign: bool = False,
         require_login: bool = False,
-    ) -> Request[Any] | PaginatedRequest[Any, Any] | RefreshableRequest[Any, Any]:
+    ) -> Request[Any] | ItemPaginatedRequest[Any, Any] | ItemRefreshableRequest[Any, Any]:
         """构建可 await 的请求描述符.
 
         Args:
@@ -244,7 +250,7 @@ class ApiModule:
             ValueError: 如果同时提供 pager_strategy 和 refresh_strategy 时抛出.
             CredentialInvalidError: 如果 require_login 为 True 且凭证无效时抛出.
         """
-        from ..core.request import PaginatedRequest, RefreshableRequest, Request
+        from ..core.request import ItemPaginatedRequest, ItemRefreshableRequest, Request
 
         if pager_strategy is not None and refresh_strategy is not None:
             raise ValueError("pager_strategy 与 refresh_strategy 不能同时声明")
@@ -268,7 +274,7 @@ class ApiModule:
             "sign": sign,
         }
         if pager_strategy is not None:
-            return PaginatedRequest(**common_kwargs, pager_strategy=pager_strategy)
+            return ItemPaginatedRequest(**common_kwargs, pager_strategy=pager_strategy)
         if refresh_strategy is not None:
-            return RefreshableRequest(**common_kwargs, refresh_strategy=refresh_strategy)
+            return ItemRefreshableRequest(**common_kwargs, refresh_strategy=refresh_strategy)
         return Request(**common_kwargs)

--- a/qqmusic_api/modules/_base.py
+++ b/qqmusic_api/modules/_base.py
@@ -3,11 +3,10 @@
 from typing import TYPE_CHECKING, Any, overload
 
 from ..core.exceptions import CredentialInvalidError
-from ..core.pagination import PagerStrategy, RefresherStrategy
+from ..core.pagination import PagerStrategy
 from ..core.request import (
     AllowErrorCodes,
     PaginatedRequest,
-    RefreshableRequest,
     Request,
     ResponseModel,
 )
@@ -95,7 +94,6 @@ class ApiModule:
         allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
         pager_strategy: None = None,
-        refresh_strategy: None = None,
         sign: bool = False,
         require_login: bool = False,
     ) -> Request[dict[str, Any]]: ...
@@ -116,31 +114,9 @@ class ApiModule:
         allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
         pager_strategy: PagerStrategy[dict[str, Any]],
-        refresh_strategy: None = None,
         sign: bool = False,
         require_login: bool = False,
     ) -> PaginatedRequest[dict[str, Any]]: ...
-
-    @overload
-    def _build_request(
-        self,
-        module: str,
-        method: str,
-        param: dict[str, Any],
-        response_model: None = None,
-        comm: dict[str, Any] | None = None,
-        *,
-        override_comm: bool = False,
-        preserve_bool: bool = False,
-        credential: "Credential | None" = None,
-        platform: Platform | None = None,
-        allow_error_codes: AllowErrorCodes | None = None,
-        parse_on_allow: bool = False,
-        pager_strategy: None = None,
-        refresh_strategy: RefresherStrategy[dict[str, Any]],
-        sign: bool = False,
-        require_login: bool = False,
-    ) -> RefreshableRequest[dict[str, Any]]: ...
 
     @overload
     def _build_request(
@@ -158,7 +134,6 @@ class ApiModule:
         allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
         pager_strategy: None = None,
-        refresh_strategy: None = None,
         sign: bool = False,
         require_login: bool = False,
     ) -> Request[ResponseModel]: ...
@@ -179,31 +154,9 @@ class ApiModule:
         allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
         pager_strategy: PagerStrategy[ResponseModel],
-        refresh_strategy: None = None,
         sign: bool = False,
         require_login: bool = False,
     ) -> PaginatedRequest[ResponseModel]: ...
-
-    @overload
-    def _build_request(
-        self,
-        module: str,
-        method: str,
-        param: dict[str, Any],
-        response_model: type[ResponseModel],
-        comm: dict[str, Any] | None = None,
-        *,
-        override_comm: bool = False,
-        preserve_bool: bool = False,
-        credential: "Credential | None" = None,
-        platform: Platform | None = None,
-        allow_error_codes: AllowErrorCodes | None = None,
-        parse_on_allow: bool = False,
-        pager_strategy: None = None,
-        refresh_strategy: RefresherStrategy[ResponseModel],
-        sign: bool = False,
-        require_login: bool = False,
-    ) -> RefreshableRequest[ResponseModel]: ...
 
     def _build_request(
         self,
@@ -220,10 +173,9 @@ class ApiModule:
         allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
         pager_strategy: PagerStrategy[Any] | None = None,
-        refresh_strategy: RefresherStrategy[Any] | None = None,
         sign: bool = False,
         require_login: bool = False,
-    ) -> Request[Any] | PaginatedRequest[Any] | RefreshableRequest[Any]:
+    ) -> Request[Any] | PaginatedRequest[Any]:
         """构建可 await 的请求描述符.
 
         Args:
@@ -239,7 +191,6 @@ class ApiModule:
             allow_error_codes: 允许放行的业务非零错误码.
             parse_on_allow: 为 True 时, 匹配 `allow_error_codes` 的响应仍走模型解析而非返回原始字典.
             pager_strategy: 分页策略描述符. 提供后则升级为 `PaginatedRequest`.
-            refresh_strategy: 换一批策略描述符. 提供后则升级为 `RefreshableRequest`.
             sign: 是否对请求进行签名.
             require_login: 为 True 时, 在构建请求前校验凭证有效性.
 
@@ -247,13 +198,9 @@ class ApiModule:
             组装好的 Request 或衍生子类描述符.
 
         Raises:
-            ValueError: 如果同时提供 pager_strategy 和 refresh_strategy 时抛出.
             CredentialInvalidError: 如果 require_login 为 True 且凭证无效时抛出.
         """
-        from ..core.request import PaginatedRequest, RefreshableRequest, Request
-
-        if pager_strategy is not None and refresh_strategy is not None:
-            raise ValueError("pager_strategy 与 refresh_strategy 不能同时声明")
+        from ..core.request import PaginatedRequest, Request
 
         if require_login:
             credential = self._require_login(credential)
@@ -275,6 +222,4 @@ class ApiModule:
         }
         if pager_strategy is not None:
             return PaginatedRequest(**common_kwargs, pager_strategy=pager_strategy)
-        if refresh_strategy is not None:
-            return RefreshableRequest(**common_kwargs, refresh_strategy=refresh_strategy)
         return Request(**common_kwargs)

--- a/qqmusic_api/modules/_base.py
+++ b/qqmusic_api/modules/_base.py
@@ -213,11 +213,11 @@ class ApiModule:
         platform: Platform | None = None,
         allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
-        pager_strategy: PagerStrategy | None = None,
-        refresh_strategy: RefresherStrategy | None = None,
+        pager_strategy: PagerStrategy[Any, Any, Any] | None = None,
+        refresh_strategy: RefresherStrategy[Any, Any, Any] | None = None,
         sign: bool = False,
         require_login: bool = False,
-    ) -> Request[Any] | PaginatedRequest[Any] | RefreshableRequest[Any]:
+    ) -> Request[Any] | PaginatedRequest[Any, Any] | RefreshableRequest[Any, Any]:
         """构建可 await 的请求描述符.
 
         Args:

--- a/qqmusic_api/modules/_base.py
+++ b/qqmusic_api/modules/_base.py
@@ -3,11 +3,11 @@
 from typing import TYPE_CHECKING, Any, overload
 
 from ..core.exceptions import CredentialInvalidError
-from ..core.pagination import ItemT_co, PagerStrategy, RefresherStrategy
+from ..core.pagination import PagerStrategy, RefresherStrategy
 from ..core.request import (
     AllowErrorCodes,
-    ItemPaginatedRequest,
-    ItemRefreshableRequest,
+    PaginatedRequest,
+    RefreshableRequest,
     Request,
     ResponseModel,
 )
@@ -84,7 +84,7 @@ class ApiModule:
         self,
         module: str,
         method: str,
-        param: dict[str, Any] | dict[int, Any],
+        param: dict[str, Any],
         response_model: None = None,
         comm: dict[str, Any] | None = None,
         *,
@@ -105,7 +105,7 @@ class ApiModule:
         self,
         module: str,
         method: str,
-        param: dict[str, Any] | dict[int, Any],
+        param: dict[str, Any],
         response_model: None = None,
         comm: dict[str, Any] | None = None,
         *,
@@ -115,18 +115,18 @@ class ApiModule:
         platform: Platform | None = None,
         allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
-        pager_strategy: PagerStrategy[Any, dict[str, Any], ItemT_co],
+        pager_strategy: PagerStrategy[dict[str, Any]],
         refresh_strategy: None = None,
         sign: bool = False,
         require_login: bool = False,
-    ) -> ItemPaginatedRequest[dict[str, Any], ItemT_co]: ...
+    ) -> PaginatedRequest[dict[str, Any]]: ...
 
     @overload
     def _build_request(
         self,
         module: str,
         method: str,
-        param: dict[str, Any] | dict[int, Any],
+        param: dict[str, Any],
         response_model: None = None,
         comm: dict[str, Any] | None = None,
         *,
@@ -137,17 +137,17 @@ class ApiModule:
         allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
         pager_strategy: None = None,
-        refresh_strategy: RefresherStrategy[Any, dict[str, Any], ItemT_co],
+        refresh_strategy: RefresherStrategy[dict[str, Any]],
         sign: bool = False,
         require_login: bool = False,
-    ) -> ItemRefreshableRequest[dict[str, Any], ItemT_co]: ...
+    ) -> RefreshableRequest[dict[str, Any]]: ...
 
     @overload
     def _build_request(
         self,
         module: str,
         method: str,
-        param: dict[str, Any] | dict[int, Any],
+        param: dict[str, Any],
         response_model: type[ResponseModel],
         comm: dict[str, Any] | None = None,
         *,
@@ -168,7 +168,7 @@ class ApiModule:
         self,
         module: str,
         method: str,
-        param: dict[str, Any] | dict[int, Any],
+        param: dict[str, Any],
         response_model: type[ResponseModel],
         comm: dict[str, Any] | None = None,
         *,
@@ -178,18 +178,18 @@ class ApiModule:
         platform: Platform | None = None,
         allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
-        pager_strategy: PagerStrategy[Any, ResponseModel, ItemT_co],
+        pager_strategy: PagerStrategy[ResponseModel],
         refresh_strategy: None = None,
         sign: bool = False,
         require_login: bool = False,
-    ) -> ItemPaginatedRequest[ResponseModel, ItemT_co]: ...
+    ) -> PaginatedRequest[ResponseModel]: ...
 
     @overload
     def _build_request(
         self,
         module: str,
         method: str,
-        param: dict[str, Any] | dict[int, Any],
+        param: dict[str, Any],
         response_model: type[ResponseModel],
         comm: dict[str, Any] | None = None,
         *,
@@ -200,16 +200,16 @@ class ApiModule:
         allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
         pager_strategy: None = None,
-        refresh_strategy: RefresherStrategy[Any, ResponseModel, ItemT_co],
+        refresh_strategy: RefresherStrategy[ResponseModel],
         sign: bool = False,
         require_login: bool = False,
-    ) -> ItemRefreshableRequest[ResponseModel, ItemT_co]: ...
+    ) -> RefreshableRequest[ResponseModel]: ...
 
     def _build_request(
         self,
         module: str,
         method: str,
-        param: dict[str, Any] | dict[int, Any],
+        param: dict[str, Any],
         response_model: type[ResponseModel] | None = None,
         comm: dict[str, Any] | None = None,
         *,
@@ -219,11 +219,11 @@ class ApiModule:
         platform: Platform | None = None,
         allow_error_codes: AllowErrorCodes | None = None,
         parse_on_allow: bool = False,
-        pager_strategy: PagerStrategy[Any, Any, Any] | None = None,
-        refresh_strategy: RefresherStrategy[Any, Any, Any] | None = None,
+        pager_strategy: PagerStrategy[Any] | None = None,
+        refresh_strategy: RefresherStrategy[Any] | None = None,
         sign: bool = False,
         require_login: bool = False,
-    ) -> Request[Any] | ItemPaginatedRequest[Any, Any] | ItemRefreshableRequest[Any, Any]:
+    ) -> Request[Any] | PaginatedRequest[Any] | RefreshableRequest[Any]:
         """构建可 await 的请求描述符.
 
         Args:
@@ -250,7 +250,7 @@ class ApiModule:
             ValueError: 如果同时提供 pager_strategy 和 refresh_strategy 时抛出.
             CredentialInvalidError: 如果 require_login 为 True 且凭证无效时抛出.
         """
-        from ..core.request import ItemPaginatedRequest, ItemRefreshableRequest, Request
+        from ..core.request import PaginatedRequest, RefreshableRequest, Request
 
         if pager_strategy is not None and refresh_strategy is not None:
             raise ValueError("pager_strategy 与 refresh_strategy 不能同时声明")
@@ -274,7 +274,7 @@ class ApiModule:
             "sign": sign,
         }
         if pager_strategy is not None:
-            return ItemPaginatedRequest(**common_kwargs, pager_strategy=pager_strategy)
+            return PaginatedRequest(**common_kwargs, pager_strategy=pager_strategy)
         if refresh_strategy is not None:
-            return ItemRefreshableRequest(**common_kwargs, refresh_strategy=refresh_strategy)
+            return RefreshableRequest(**common_kwargs, refresh_strategy=refresh_strategy)
         return Request(**common_kwargs)

--- a/qqmusic_api/modules/album.py
+++ b/qqmusic_api/modules/album.py
@@ -60,6 +60,7 @@ class AlbumApi(ApiModule):
             pager_strategy=OffsetStrategy[Any, GetAlbumSongResponse](
                 offset_key="begin",
                 page_size_key="num",
+                items_extractor=lambda response: response.song_list,
                 total_extractor=lambda response: response.total_num,
                 count_extractor=lambda response: len(response.song_list),
             ),
@@ -81,6 +82,7 @@ class AlbumApi(ApiModule):
             pager_strategy=OffsetStrategy[Any, GetNewAlbumResponse](
                 offset_key="start",
                 page_size_key="num",
+                items_extractor=lambda response: response.albums,
                 total_extractor=lambda response: response.total,
                 count_extractor=lambda response: len(response.albums),
             ),

--- a/qqmusic_api/modules/album.py
+++ b/qqmusic_api/modules/album.py
@@ -9,7 +9,6 @@ from ..models.album import (
     GetAlbumSongResponse,
     GetNewAlbumResponse,
 )
-from ..models.base import Album, Song
 from ..models.request import Credential
 from ._base import ApiModule
 
@@ -58,14 +57,13 @@ class AlbumApi(ApiModule):
             method="GetAlbumSongList",
             param=param,
             response_model=GetAlbumSongResponse,
-            pager_strategy=OffsetStrategy[Any, GetAlbumSongResponse, Song](
+            pager_strategy=OffsetStrategy[GetAlbumSongResponse](
                 offset_key="begin",
                 page_size_key="num",
-                items_extractor=lambda response: response.song_list,
-                total_extractor=lambda response: response.total_num,
-                count_extractor=lambda response: len(response.song_list),
+                total_extractor=lambda r: r.total_num,
+                count_extractor=lambda r: len(r.song_list),
             ),
-        )
+        ).with_extractor(lambda r: r.song_list)
 
     def get_new_album(self, area: int = 1, num: int = 20, page: int = 1):
         """获取新碟上架列表.
@@ -80,14 +78,13 @@ class AlbumApi(ApiModule):
             method="get_new_album_info",
             param={"area": area, "num": num, "start": num * (page - 1)},
             response_model=GetNewAlbumResponse,
-            pager_strategy=OffsetStrategy[Any, GetNewAlbumResponse, Album](
+            pager_strategy=OffsetStrategy[GetNewAlbumResponse](
                 offset_key="start",
                 page_size_key="num",
-                items_extractor=lambda response: response.albums,
-                total_extractor=lambda response: response.total,
-                count_extractor=lambda response: len(response.albums),
+                total_extractor=lambda r: r.total,
+                count_extractor=lambda r: len(r.albums),
             ),
-        )
+        ).with_extractor(lambda r: r.albums)
 
     def fav_album(self, album_id: int | list[int], *, credential: Credential | None = None):
         """收藏专辑到当前登录用户.

--- a/qqmusic_api/modules/album.py
+++ b/qqmusic_api/modules/album.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from ..core.pagination import OffsetStrategy, PagerMeta, ResponseAdapter
+from ..core.pagination import OffsetStrategy
 from ..models.album import (
     AlbumFavWriteResponse,
     GetAlbumDetailResponse,
@@ -57,9 +57,11 @@ class AlbumApi(ApiModule):
             method="GetAlbumSongList",
             param=param,
             response_model=GetAlbumSongResponse,
-            pager_meta=PagerMeta(
-                strategy=OffsetStrategy(offset_key="begin", page_size_key="num"),
-                adapter=ResponseAdapter(total="total_num", count=lambda response: len(response.song_list)),
+            pager_strategy=OffsetStrategy[Any, GetAlbumSongResponse](
+                offset_key="begin",
+                page_size_key="num",
+                total_extractor=lambda response: response.total_num,
+                count_extractor=lambda response: len(response.song_list),
             ),
         )
 
@@ -76,9 +78,11 @@ class AlbumApi(ApiModule):
             method="get_new_album_info",
             param={"area": area, "num": num, "start": num * (page - 1)},
             response_model=GetNewAlbumResponse,
-            pager_meta=PagerMeta(
-                strategy=OffsetStrategy(offset_key="start", page_size_key="num"),
-                adapter=ResponseAdapter(total="total", count=lambda response: len(response.albums)),
+            pager_strategy=OffsetStrategy[Any, GetNewAlbumResponse](
+                offset_key="start",
+                page_size_key="num",
+                total_extractor=lambda response: response.total,
+                count_extractor=lambda response: len(response.albums),
             ),
         )
 

--- a/qqmusic_api/modules/album.py
+++ b/qqmusic_api/modules/album.py
@@ -9,6 +9,7 @@ from ..models.album import (
     GetAlbumSongResponse,
     GetNewAlbumResponse,
 )
+from ..models.base import Album, Song
 from ..models.request import Credential
 from ._base import ApiModule
 
@@ -57,7 +58,7 @@ class AlbumApi(ApiModule):
             method="GetAlbumSongList",
             param=param,
             response_model=GetAlbumSongResponse,
-            pager_strategy=OffsetStrategy[Any, GetAlbumSongResponse](
+            pager_strategy=OffsetStrategy[Any, GetAlbumSongResponse, Song](
                 offset_key="begin",
                 page_size_key="num",
                 items_extractor=lambda response: response.song_list,
@@ -79,7 +80,7 @@ class AlbumApi(ApiModule):
             method="get_new_album_info",
             param={"area": area, "num": num, "start": num * (page - 1)},
             response_model=GetNewAlbumResponse,
-            pager_strategy=OffsetStrategy[Any, GetNewAlbumResponse](
+            pager_strategy=OffsetStrategy[Any, GetNewAlbumResponse, Album](
                 offset_key="start",
                 page_size_key="num",
                 items_extractor=lambda response: response.albums,

--- a/qqmusic_api/modules/comment.py
+++ b/qqmusic_api/modules/comment.py
@@ -18,7 +18,7 @@ from ..models.request import Credential
 from ._base import ApiModule
 
 
-def _build_comment_pager_strategy():
+def _build_comment_pager_strategy() -> MultiFieldContinuationStrategy[CommentListResponse]:
     """构建评论列表接口使用的 continuation 策略."""
 
     def build_next_params(
@@ -227,7 +227,7 @@ class CommentApi(ApiModule):
             "GetSongTsCmList",
             params,
             response_model=MomentCommentResponse,
-            pager_strategy=CursorStrategy(
+            pager_strategy=CursorStrategy[MomentCommentResponse](
                 cursor_key="LastPos",
                 has_more_extractor=lambda response: response.has_more == 1,
                 cursor_extractor=lambda response: response.next_pos,

--- a/qqmusic_api/modules/comment.py
+++ b/qqmusic_api/modules/comment.py
@@ -11,14 +11,16 @@ from ..models.comment import (
     AddCommentResponse,
     CommentBizType,
     CommentCountResponse,
+    CommentItem,
     CommentListResponse,
+    MomentCommentItem,
     MomentCommentResponse,
 )
 from ..models.request import Credential
 from ._base import ApiModule
 
 
-def _build_comment_pager_strategy() -> MultiFieldContinuationStrategy[Any, CommentListResponse]:
+def _build_comment_pager_strategy() -> MultiFieldContinuationStrategy[Any, CommentListResponse, CommentItem]:
     """构建评论列表接口使用的 continuation 策略."""
 
     def build_next_params(
@@ -228,7 +230,7 @@ class CommentApi(ApiModule):
             "GetSongTsCmList",
             params,
             response_model=MomentCommentResponse,
-            pager_strategy=CursorStrategy[Any, MomentCommentResponse](
+            pager_strategy=CursorStrategy[Any, MomentCommentResponse, MomentCommentItem](
                 cursor_key="LastPos",
                 has_more_extractor=lambda response: bool(response.has_more),
                 cursor_extractor=lambda response: response.next_pos,

--- a/qqmusic_api/modules/comment.py
+++ b/qqmusic_api/modules/comment.py
@@ -232,7 +232,7 @@ class CommentApi(ApiModule):
             response_model=MomentCommentResponse,
             pager_strategy=CursorStrategy[Any, MomentCommentResponse, MomentCommentItem](
                 cursor_key="LastPos",
-                has_more_extractor=lambda response: bool(response.has_more),
+                has_more_extractor=lambda response: response.has_more == 1,
                 cursor_extractor=lambda response: response.next_pos,
                 items_extractor=lambda response: response.comments,
             ),

--- a/qqmusic_api/modules/comment.py
+++ b/qqmusic_api/modules/comment.py
@@ -38,6 +38,7 @@ def _build_comment_pager_strategy() -> MultiFieldContinuationStrategy[Any, Comme
     return MultiFieldContinuationStrategy(
         build_next_params,
         has_more_extractor=lambda response: bool(response.has_more),
+        items_extractor=lambda response: response.comments,
         context_name="comment_list",
     )
 
@@ -231,6 +232,7 @@ class CommentApi(ApiModule):
                 cursor_key="LastPos",
                 has_more_extractor=lambda response: bool(response.has_more),
                 cursor_extractor=lambda response: response.next_pos,
+                items_extractor=lambda response: response.comments,
             ),
         )
 

--- a/qqmusic_api/modules/comment.py
+++ b/qqmusic_api/modules/comment.py
@@ -5,9 +5,7 @@ from typing import Any, cast
 from ..core.pagination import (
     CursorStrategy,
     MultiFieldContinuationStrategy,
-    PagerMeta,
     PaginationParams,
-    ResponseAdapter,
 )
 from ..models.comment import (
     AddCommentResponse,
@@ -20,29 +18,27 @@ from ..models.request import Credential
 from ._base import ApiModule
 
 
-def _build_comment_pager_meta() -> PagerMeta:
+def _build_comment_pager_strategy() -> MultiFieldContinuationStrategy[Any, CommentListResponse]:
     """构建评论列表接口使用的 continuation 策略."""
 
     def build_next_params(
         params: PaginationParams,
         response: CommentListResponse,
-        adapter: ResponseAdapter,
     ) -> PaginationParams | None:
-        next_seq_no = adapter.get_cursor(response)
-        if next_seq_no is None:
+        if not response.has_more:
+            return None
+        cursor = response.comments[-1].seq_no if response.comments else None
+        if cursor is None:
             return None
         next_params = cast("dict[str, Any]", params.copy())
         next_params["PageNum"] = next_params["PageNum"] + 1
-        next_params["LastCommentSeqNo"] = next_seq_no
+        next_params["LastCommentSeqNo"] = cursor
         return next_params
 
-    return PagerMeta(
-        strategy=MultiFieldContinuationStrategy(build_next_params, context_name="comment_list"),
-        adapter=ResponseAdapter(
-            has_more_flag="has_more",
-            total="total",
-            cursor=lambda response: response.comments[-1].seq_no if response.comments else None,
-        ),
+    return MultiFieldContinuationStrategy(
+        build_next_params,
+        has_more_extractor=lambda response: bool(response.has_more),
+        context_name="comment_list",
     )
 
 
@@ -116,7 +112,7 @@ class CommentApi(ApiModule):
             "GetHotCommentList",
             params,
             response_model=CommentListResponse,
-            pager_meta=_build_comment_pager_meta(),
+            pager_strategy=_build_comment_pager_strategy(),
         )
 
     def get_new_comments(
@@ -156,7 +152,7 @@ class CommentApi(ApiModule):
             "GetNewCommentList",
             params,
             response_model=CommentListResponse,
-            pager_meta=_build_comment_pager_meta(),
+            pager_strategy=_build_comment_pager_strategy(),
         )
 
     def get_recommend_comments(
@@ -196,7 +192,7 @@ class CommentApi(ApiModule):
             "GetRecCommentList",
             params,
             response_model=CommentListResponse,
-            pager_meta=_build_comment_pager_meta(),
+            pager_strategy=_build_comment_pager_strategy(),
         )
 
     def get_moment_comments(
@@ -231,9 +227,10 @@ class CommentApi(ApiModule):
             "GetSongTsCmList",
             params,
             response_model=MomentCommentResponse,
-            pager_meta=PagerMeta(
-                strategy=CursorStrategy(cursor_key="LastPos"),
-                adapter=ResponseAdapter(has_more_flag="has_more", cursor="next_pos"),
+            pager_strategy=CursorStrategy[Any, MomentCommentResponse](
+                cursor_key="LastPos",
+                has_more_extractor=lambda response: bool(response.has_more),
+                cursor_extractor=lambda response: response.next_pos,
             ),
         )
 

--- a/qqmusic_api/modules/comment.py
+++ b/qqmusic_api/modules/comment.py
@@ -1,6 +1,6 @@
 """评论模块."""
 
-from typing import Any, cast
+from typing import Any
 
 from ..core.pagination import (
     CursorStrategy,
@@ -11,36 +11,33 @@ from ..models.comment import (
     AddCommentResponse,
     CommentBizType,
     CommentCountResponse,
-    CommentItem,
     CommentListResponse,
-    MomentCommentItem,
     MomentCommentResponse,
 )
 from ..models.request import Credential
 from ._base import ApiModule
 
 
-def _build_comment_pager_strategy() -> MultiFieldContinuationStrategy[Any, CommentListResponse, CommentItem]:
+def _build_comment_pager_strategy():
     """构建评论列表接口使用的 continuation 策略."""
 
     def build_next_params(
         params: PaginationParams,
         response: CommentListResponse,
-    ) -> PaginationParams | None:
+    ):
         if not response.has_more:
             return None
         cursor = response.comments[-1].seq_no if response.comments else None
         if cursor is None:
             return None
-        next_params = cast("dict[str, Any]", params.copy())
+        next_params = params.copy()
         next_params["PageNum"] = next_params["PageNum"] + 1
         next_params["LastCommentSeqNo"] = cursor
         return next_params
 
-    return MultiFieldContinuationStrategy(
+    return MultiFieldContinuationStrategy[CommentListResponse](
         build_next_params,
-        has_more_extractor=lambda response: bool(response.has_more),
-        items_extractor=lambda response: response.comments,
+        has_more_extractor=lambda r: bool(r.has_more),
         context_name="comment_list",
     )
 
@@ -116,7 +113,7 @@ class CommentApi(ApiModule):
             params,
             response_model=CommentListResponse,
             pager_strategy=_build_comment_pager_strategy(),
-        )
+        ).with_extractor(lambda r: r.comments)
 
     def get_new_comments(
         self,
@@ -156,7 +153,7 @@ class CommentApi(ApiModule):
             params,
             response_model=CommentListResponse,
             pager_strategy=_build_comment_pager_strategy(),
-        )
+        ).with_extractor(lambda r: r.comments)
 
     def get_recommend_comments(
         self,
@@ -196,7 +193,7 @@ class CommentApi(ApiModule):
             params,
             response_model=CommentListResponse,
             pager_strategy=_build_comment_pager_strategy(),
-        )
+        ).with_extractor(lambda r: r.comments)
 
     def get_moment_comments(
         self,
@@ -230,13 +227,12 @@ class CommentApi(ApiModule):
             "GetSongTsCmList",
             params,
             response_model=MomentCommentResponse,
-            pager_strategy=CursorStrategy[Any, MomentCommentResponse, MomentCommentItem](
+            pager_strategy=CursorStrategy(
                 cursor_key="LastPos",
                 has_more_extractor=lambda response: response.has_more == 1,
                 cursor_extractor=lambda response: response.next_pos,
-                items_extractor=lambda response: response.comments,
             ),
-        )
+        ).with_extractor(lambda r: r.comments)
 
     def add_comment(
         self,

--- a/qqmusic_api/modules/mv.py
+++ b/qqmusic_api/modules/mv.py
@@ -97,6 +97,7 @@ class MvApi(ApiModule):
             pager_strategy=OffsetStrategy[Any, GetMvListResponse](
                 offset_key="start",
                 page_size_key="size",
+                items_extractor=lambda response: response.items,
                 total_extractor=lambda response: response.total,
                 count_extractor=lambda response: len(response.items),
             ),

--- a/qqmusic_api/modules/mv.py
+++ b/qqmusic_api/modules/mv.py
@@ -1,6 +1,8 @@
 """MV 相关 API."""
 
-from ..core.pagination import OffsetStrategy, PagerMeta, ResponseAdapter
+from typing import Any
+
+from ..core.pagination import OffsetStrategy
 from ..models.mv import GetMvDetailResponse, GetMvListResponse, GetMvUrlsResponse
 from ..utils.common import get_guid
 from ._base import ApiModule
@@ -92,8 +94,10 @@ class MvApi(ApiModule):
             method="GetAllocMvInfo",
             param={"area": area, "version": version, "order": order, "start": num * (page - 1), "size": num},
             response_model=GetMvListResponse,
-            pager_meta=PagerMeta(
-                strategy=OffsetStrategy(offset_key="start", page_size_key="size"),
-                adapter=ResponseAdapter(total="total", count=lambda response: len(response.items)),
+            pager_strategy=OffsetStrategy[Any, GetMvListResponse](
+                offset_key="start",
+                page_size_key="size",
+                total_extractor=lambda response: response.total,
+                count_extractor=lambda response: len(response.items),
             ),
         )

--- a/qqmusic_api/modules/mv.py
+++ b/qqmusic_api/modules/mv.py
@@ -1,9 +1,6 @@
 """MV 相关 API."""
 
-from typing import Any
-
 from ..core.pagination import OffsetStrategy
-from ..models.base import MV
 from ..models.mv import GetMvDetailResponse, GetMvListResponse, GetMvUrlsResponse
 from ..utils.common import get_guid
 from ._base import ApiModule
@@ -95,11 +92,10 @@ class MvApi(ApiModule):
             method="GetAllocMvInfo",
             param={"area": area, "version": version, "order": order, "start": num * (page - 1), "size": num},
             response_model=GetMvListResponse,
-            pager_strategy=OffsetStrategy[Any, GetMvListResponse, MV](
+            pager_strategy=OffsetStrategy[GetMvListResponse](
                 offset_key="start",
                 page_size_key="size",
-                items_extractor=lambda response: response.items,
-                total_extractor=lambda response: response.total,
-                count_extractor=lambda response: len(response.items),
+                total_extractor=lambda r: r.total,
+                count_extractor=lambda r: len(r.items),
             ),
-        )
+        ).with_extractor(lambda r: r.items)

--- a/qqmusic_api/modules/mv.py
+++ b/qqmusic_api/modules/mv.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from ..core.pagination import OffsetStrategy
+from ..models.base import MV
 from ..models.mv import GetMvDetailResponse, GetMvListResponse, GetMvUrlsResponse
 from ..utils.common import get_guid
 from ._base import ApiModule
@@ -94,7 +95,7 @@ class MvApi(ApiModule):
             method="GetAllocMvInfo",
             param={"area": area, "version": version, "order": order, "start": num * (page - 1), "size": num},
             response_model=GetMvListResponse,
-            pager_strategy=OffsetStrategy[Any, GetMvListResponse](
+            pager_strategy=OffsetStrategy[Any, GetMvListResponse, MV](
                 offset_key="start",
                 page_size_key="size",
                 items_extractor=lambda response: response.items,

--- a/qqmusic_api/modules/private_message.py
+++ b/qqmusic_api/modules/private_message.py
@@ -8,7 +8,9 @@ from ..models.private_message import (
     PrivateChatEntriesResponse,
     PrivateConfigResponse,
     PrivateMediaMessageDetailsResponse,
+    PrivateMessageInfo,
     PrivateMessageListResponse,
+    PrivateMessageSession,
     PrivateMusicianCardResponse,
     PrivateOperationResponse,
     PrivateSafetyHintResponse,
@@ -87,7 +89,7 @@ class PrivateMessageApi(ApiModule):
             require_login=True,
             platform=Platform.ANDROID,
             response_model=PrivateSessionListResponse,
-            pager_strategy=MultiFieldContinuationStrategy[Any, PrivateSessionListResponse](
+            pager_strategy=MultiFieldContinuationStrategy[Any, PrivateSessionListResponse, PrivateMessageSession](
                 _build_session_list_next_params,
                 has_more_extractor=lambda response: response.has_more == 1,
                 items_extractor=lambda response: response.sessions,
@@ -160,7 +162,7 @@ class PrivateMessageApi(ApiModule):
             require_login=True,
             platform=Platform.ANDROID,
             response_model=PrivateMessageListResponse,
-            pager_strategy=MultiFieldContinuationStrategy[Any, PrivateMessageListResponse](
+            pager_strategy=MultiFieldContinuationStrategy[Any, PrivateMessageListResponse, PrivateMessageInfo](
                 _build_message_list_next_params,
                 has_more_extractor=lambda response: response.has_more == 1,
                 items_extractor=lambda response: response.messages,

--- a/qqmusic_api/modules/private_message.py
+++ b/qqmusic_api/modules/private_message.py
@@ -24,7 +24,9 @@ PRIVATE_MSG_READ_MODULE = "music.privateMsg.PrivateMsgRead"
 PRIVATE_MSG_WRITE_MODULE = "music.privateMsg.PrivateMsgWrite"
 
 
-def _build_session_list_next_params(params: dict[Any, Any], response: PrivateSessionListResponse):
+def _build_session_list_next_params(
+    params: dict[str, Any], response: PrivateSessionListResponse
+) -> dict[str, Any] | None:
     """根据最后一个会话构造会话列表下一页参数."""
     if not response.sessions:
         return None
@@ -32,7 +34,9 @@ def _build_session_list_next_params(params: dict[Any, Any], response: PrivateSes
     return {**params, "last_id": last_session.session_id, "last_time": last_session.sort_time}
 
 
-def _build_message_list_next_params(params: dict[Any, Any], response: PrivateMessageListResponse):
+def _build_message_list_next_params(
+    params: dict[str, Any], response: PrivateMessageListResponse
+) -> dict[str, Any] | None:
     """根据最后一条消息构造消息列表下一页参数."""
     if not response.messages:
         return None

--- a/qqmusic_api/modules/private_message.py
+++ b/qqmusic_api/modules/private_message.py
@@ -90,6 +90,7 @@ class PrivateMessageApi(ApiModule):
             pager_strategy=MultiFieldContinuationStrategy[Any, PrivateSessionListResponse](
                 _build_session_list_next_params,
                 has_more_extractor=lambda response: response.has_more == 1,
+                items_extractor=lambda response: response.sessions,
                 context_name="private_message_session_list",
             ),
         )
@@ -162,6 +163,7 @@ class PrivateMessageApi(ApiModule):
             pager_strategy=MultiFieldContinuationStrategy[Any, PrivateMessageListResponse](
                 _build_message_list_next_params,
                 has_more_extractor=lambda response: response.has_more == 1,
+                items_extractor=lambda response: response.messages,
                 context_name="private_message_list",
             ),
         )

--- a/qqmusic_api/modules/private_message.py
+++ b/qqmusic_api/modules/private_message.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from ..core import Platform
-from ..core.pagination import MultiFieldContinuationStrategy, PagerMeta, ResponseAdapter
+from ..core.pagination import MultiFieldContinuationStrategy
 from ..models.private_message import (
     PrivateChatEntriesResponse,
     PrivateConfigResponse,
@@ -22,7 +22,7 @@ PRIVATE_MSG_READ_MODULE = "music.privateMsg.PrivateMsgRead"
 PRIVATE_MSG_WRITE_MODULE = "music.privateMsg.PrivateMsgWrite"
 
 
-def _build_session_list_next_params(params: dict[Any, Any], response: PrivateSessionListResponse, _: ResponseAdapter):
+def _build_session_list_next_params(params: dict[Any, Any], response: PrivateSessionListResponse):
     """根据最后一个会话构造会话列表下一页参数."""
     if not response.sessions:
         return None
@@ -30,7 +30,7 @@ def _build_session_list_next_params(params: dict[Any, Any], response: PrivateSes
     return {**params, "last_id": last_session.session_id, "last_time": last_session.sort_time}
 
 
-def _build_message_list_next_params(params: dict[Any, Any], response: PrivateMessageListResponse, _: ResponseAdapter):
+def _build_message_list_next_params(params: dict[Any, Any], response: PrivateMessageListResponse):
     """根据最后一条消息构造消息列表下一页参数."""
     if not response.messages:
         return None
@@ -87,12 +87,10 @@ class PrivateMessageApi(ApiModule):
             require_login=True,
             platform=Platform.ANDROID,
             response_model=PrivateSessionListResponse,
-            pager_meta=PagerMeta(
-                strategy=MultiFieldContinuationStrategy(
-                    _build_session_list_next_params,
-                    context_name="private_message_session_list",
-                ),
-                adapter=ResponseAdapter(has_more_flag=lambda response: response.has_more == 1),
+            pager_strategy=MultiFieldContinuationStrategy[Any, PrivateSessionListResponse](
+                _build_session_list_next_params,
+                has_more_extractor=lambda response: response.has_more == 1,
+                context_name="private_message_session_list",
             ),
         )
 
@@ -161,12 +159,10 @@ class PrivateMessageApi(ApiModule):
             require_login=True,
             platform=Platform.ANDROID,
             response_model=PrivateMessageListResponse,
-            pager_meta=PagerMeta(
-                strategy=MultiFieldContinuationStrategy(
-                    _build_message_list_next_params,
-                    context_name="private_message_list",
-                ),
-                adapter=ResponseAdapter(has_more_flag=lambda response: response.has_more == 1),
+            pager_strategy=MultiFieldContinuationStrategy[Any, PrivateMessageListResponse](
+                _build_message_list_next_params,
+                has_more_extractor=lambda response: response.has_more == 1,
+                context_name="private_message_list",
             ),
         )
 

--- a/qqmusic_api/modules/private_message.py
+++ b/qqmusic_api/modules/private_message.py
@@ -8,9 +8,7 @@ from ..models.private_message import (
     PrivateChatEntriesResponse,
     PrivateConfigResponse,
     PrivateMediaMessageDetailsResponse,
-    PrivateMessageInfo,
     PrivateMessageListResponse,
-    PrivateMessageSession,
     PrivateMusicianCardResponse,
     PrivateOperationResponse,
     PrivateSafetyHintResponse,
@@ -93,13 +91,12 @@ class PrivateMessageApi(ApiModule):
             require_login=True,
             platform=Platform.ANDROID,
             response_model=PrivateSessionListResponse,
-            pager_strategy=MultiFieldContinuationStrategy[Any, PrivateSessionListResponse, PrivateMessageSession](
+            pager_strategy=MultiFieldContinuationStrategy[PrivateSessionListResponse](
                 _build_session_list_next_params,
-                has_more_extractor=lambda response: response.has_more == 1,
-                items_extractor=lambda response: response.sessions,
+                has_more_extractor=lambda r: r.has_more == 1,
                 context_name="private_message_session_list",
             ),
-        )
+        ).with_extractor(lambda r: r.sessions)
 
     def delete_session(self, session_id: str, *, super_msg_flag: int = 0, credential: Credential | None = None):
         """删除私信会话.
@@ -166,13 +163,12 @@ class PrivateMessageApi(ApiModule):
             require_login=True,
             platform=Platform.ANDROID,
             response_model=PrivateMessageListResponse,
-            pager_strategy=MultiFieldContinuationStrategy[Any, PrivateMessageListResponse, PrivateMessageInfo](
+            pager_strategy=MultiFieldContinuationStrategy[PrivateMessageListResponse](
                 _build_message_list_next_params,
-                has_more_extractor=lambda response: response.has_more == 1,
-                items_extractor=lambda response: response.messages,
+                has_more_extractor=lambda r: r.has_more == 1,
                 context_name="private_message_list",
             ),
-        )
+        ).with_extractor(lambda r: r.messages)
 
     def send_message(
         self,

--- a/qqmusic_api/modules/recommend.py
+++ b/qqmusic_api/modules/recommend.py
@@ -8,6 +8,7 @@ from ..core.pagination import (
     PageStrategy,
     PaginationParams,
 )
+from ..models.base import SongList
 from ..models.recommend import (
     GuessRecommendResponse,
     RadarRecommendResponse,
@@ -60,7 +61,6 @@ class RecommendApi(ApiModule):
             response_model=RecommendFeedCardResponse,
             pager_strategy=MultiFieldContinuationStrategy[Any, RecommendFeedCardResponse](
                 _build_home_feed_next_params,
-                items_extractor=lambda response: response.shelves,
                 context_name="recommend_home_feed",
             ),
         )
@@ -107,7 +107,6 @@ class RecommendApi(ApiModule):
                 page_key="Page",
                 start_page=page,
                 has_more_extractor=lambda response: bool(response.has_more),
-                items_extractor=lambda response: response.songs,
             ),
         )
 
@@ -124,7 +123,7 @@ class RecommendApi(ApiModule):
             "GetRecommendFeed",
             data,
             response_model=RecommendSonglistResponse,
-            pager_strategy=CursorStrategy[Any, RecommendSonglistResponse](
+            pager_strategy=CursorStrategy[Any, RecommendSonglistResponse, SongList](
                 cursor_key="From",
                 has_more_extractor=lambda response: bool(response.has_more),
                 cursor_extractor=lambda response: response.from_limit,

--- a/qqmusic_api/modules/recommend.py
+++ b/qqmusic_api/modules/recommend.py
@@ -8,12 +8,13 @@ from ..core.pagination import (
     PageStrategy,
     PaginationParams,
 )
-from ..models.base import SongList
+from ..models.base import Song, SongList
 from ..models.recommend import (
     GuessRecommendResponse,
     RadarRecommendResponse,
     RecommendFeedCardResponse,
     RecommendNewSongResponse,
+    RecommendShelf,
     RecommendSonglistResponse,
 )
 from ..models.request import Credential
@@ -23,20 +24,25 @@ from ._base import ApiModule
 class RecommendApi(ApiModule):
     """推荐 API."""
 
-    def get_home_feed(self, data: dict[str, Any] | None = None):
+    def get_home_feed(self, page: int = 1, direction: int = 0, s_num: int = 0, v_cache: list[str] | None = None):
         """获取首页推荐 Feed.
 
         Args:
-            data: 自定义请求参数. 若未传则构造初始化参数.
+            page: 页码.
+            direction: 翻页方向, 0=首屏, 1=向后翻页.
+            s_num: 已拉取的楼层数量累加值.
+            v_cache: 已经拉取过的楼层 ID 缓存列表.
         """
-        data = data or {
-            "direction": 0,
-            "page": 1,
-            "s_num": 0,
-            "v_cache": [],
+        data: dict[str, Any] = {
+            "direction": direction,
+            "page": page,
+            "s_num": s_num,
+            "v_cache": v_cache or [],
         }
 
-        def _build_home_feed_next_params(params: PaginationParams, response: RecommendFeedCardResponse):
+        def _build_home_feed_next_params(
+            params: PaginationParams, response: RecommendFeedCardResponse
+        ) -> PaginationParams | None:
             shelf_count = len(response.shelves)
             if shelf_count == 0:
                 return None
@@ -59,8 +65,9 @@ class RecommendApi(ApiModule):
             "get_recommend_feed",
             data,
             response_model=RecommendFeedCardResponse,
-            pager_strategy=MultiFieldContinuationStrategy[Any, RecommendFeedCardResponse](
+            pager_strategy=MultiFieldContinuationStrategy[Any, RecommendFeedCardResponse, RecommendShelf](
                 _build_home_feed_next_params,
+                items_extractor=lambda response: response.shelves,
                 context_name="recommend_home_feed",
             ),
         )
@@ -103,10 +110,11 @@ class RecommendApi(ApiModule):
             "GetRadarSong",
             data,
             response_model=RadarRecommendResponse,
-            pager_strategy=PageStrategy[Any, RadarRecommendResponse](
+            pager_strategy=PageStrategy[Any, RadarRecommendResponse, Song](
                 page_key="Page",
                 start_page=page,
                 has_more_extractor=lambda response: bool(response.has_more),
+                items_extractor=lambda response: response.songs,
             ),
         )
 

--- a/qqmusic_api/modules/recommend.py
+++ b/qqmusic_api/modules/recommend.py
@@ -5,10 +5,8 @@ from typing import Any, cast
 from ..core.pagination import (
     CursorStrategy,
     MultiFieldContinuationStrategy,
-    PagerMeta,
     PageStrategy,
     PaginationParams,
-    ResponseAdapter,
 )
 from ..models.recommend import (
     GuessRecommendResponse,
@@ -24,39 +22,25 @@ from ._base import ApiModule
 class RecommendApi(ApiModule):
     """推荐 API."""
 
-    def get_home_feed(
-        self,
-        page: int = 1,
-        direction: int = 0,
-        s_num: int = 0,
-        v_cache: list[str] | None = None,
-    ):
-        """获取主页推荐.
+    def get_home_feed(self, data: dict[str, Any] | None = None):
+        """获取首页推荐 Feed.
 
         Args:
-            page: 页码.
-            direction: 刷新方向.
-            s_num: 已加载的卡片数量.
-            v_cache: 已曝光的卡片 ID 缓存, 防止重复推荐.
+            data: 自定义请求参数. 若未传则构造初始化参数.
         """
-        data: dict[str, Any] = {
-            "direction": direction,
-            "page": page,
-            "s_num": s_num,
+        data = data or {
+            "direction": 0,
+            "page": 1,
+            "s_num": 0,
+            "v_cache": [],
         }
-        if v_cache is not None:
-            data["v_cache"] = v_cache
 
-        def _build_home_feed_next_params(
-            params: PaginationParams,
-            response: RecommendFeedCardResponse,
-            adapter: ResponseAdapter,
-        ) -> PaginationParams | None:
-            shelf_count = adapter.get_count(response) or 0
-            if shelf_count <= 0:
+        def _build_home_feed_next_params(params: PaginationParams, response: RecommendFeedCardResponse):
+            shelf_count = len(response.shelves)
+            if shelf_count == 0:
                 return None
 
-            next_params = cast("dict[str, Any]", params)
+            next_params = cast("dict[str, Any]", params.copy())
             seen = {str(item) for item in next_params.get("v_cache", [])}
             for shelf in response.shelves:
                 shelf_id = str(shelf.id)
@@ -74,12 +58,9 @@ class RecommendApi(ApiModule):
             "get_recommend_feed",
             data,
             response_model=RecommendFeedCardResponse,
-            pager_meta=PagerMeta(
-                strategy=MultiFieldContinuationStrategy(
-                    _build_home_feed_next_params,
-                    context_name="recommend_home_feed",
-                ),
-                adapter=ResponseAdapter(count=lambda response: len(response.shelves)),
+            pager_strategy=MultiFieldContinuationStrategy[Any, RecommendFeedCardResponse](
+                _build_home_feed_next_params,
+                context_name="recommend_home_feed",
             ),
         )
 
@@ -121,9 +102,10 @@ class RecommendApi(ApiModule):
             "GetRadarSong",
             data,
             response_model=RadarRecommendResponse,
-            pager_meta=PagerMeta(
-                strategy=PageStrategy(page_key="Page", start_page=page),
-                adapter=ResponseAdapter(has_more_flag="has_more"),
+            pager_strategy=PageStrategy[Any, RadarRecommendResponse](
+                page_key="Page",
+                start_page=page,
+                has_more_extractor=lambda response: bool(response.has_more),
             ),
         )
 
@@ -140,9 +122,10 @@ class RecommendApi(ApiModule):
             "GetRecommendFeed",
             data,
             response_model=RecommendSonglistResponse,
-            pager_meta=PagerMeta(
-                strategy=CursorStrategy(cursor_key="From"),
-                adapter=ResponseAdapter(has_more_flag="has_more", cursor="from_limit"),
+            pager_strategy=CursorStrategy[Any, RecommendSonglistResponse](
+                cursor_key="From",
+                has_more_extractor=lambda response: bool(response.has_more),
+                cursor_extractor=lambda response: response.from_limit,
             ),
         )
 

--- a/qqmusic_api/modules/recommend.py
+++ b/qqmusic_api/modules/recommend.py
@@ -1,6 +1,6 @@
 """推荐模块."""
 
-from typing import Any, cast
+from typing import Any
 
 from ..core.pagination import (
     CursorStrategy,
@@ -8,13 +8,11 @@ from ..core.pagination import (
     PageStrategy,
     PaginationParams,
 )
-from ..models.base import Song, SongList
 from ..models.recommend import (
     GuessRecommendResponse,
     RadarRecommendResponse,
     RecommendFeedCardResponse,
     RecommendNewSongResponse,
-    RecommendShelf,
     RecommendSonglistResponse,
 )
 from ..models.request import Credential
@@ -40,14 +38,12 @@ class RecommendApi(ApiModule):
             "v_cache": v_cache or [],
         }
 
-        def _build_home_feed_next_params(
-            params: PaginationParams, response: RecommendFeedCardResponse
-        ) -> PaginationParams | None:
+        def _build_home_feed_next_params(params: PaginationParams, response: RecommendFeedCardResponse):
             shelf_count = len(response.shelves)
             if shelf_count == 0:
                 return None
 
-            next_params = cast("dict[str, Any]", params.copy())
+            next_params = params.copy()
             seen = {str(item) for item in next_params.get("v_cache", [])}
             for shelf in response.shelves:
                 shelf_id = str(shelf.id)
@@ -65,12 +61,11 @@ class RecommendApi(ApiModule):
             "get_recommend_feed",
             data,
             response_model=RecommendFeedCardResponse,
-            pager_strategy=MultiFieldContinuationStrategy[Any, RecommendFeedCardResponse, RecommendShelf](
+            pager_strategy=MultiFieldContinuationStrategy[RecommendFeedCardResponse](
                 _build_home_feed_next_params,
-                items_extractor=lambda response: response.shelves,
                 context_name="recommend_home_feed",
             ),
-        )
+        ).with_extractor(lambda r: r.shelves)
 
     def get_guess_recommend(self, *, credential: Credential | None = None):
         """获取猜你喜欢推荐.
@@ -110,13 +105,12 @@ class RecommendApi(ApiModule):
             "GetRadarSong",
             data,
             response_model=RadarRecommendResponse,
-            pager_strategy=PageStrategy[Any, RadarRecommendResponse, Song](
+            pager_strategy=PageStrategy[RadarRecommendResponse](
                 page_key="Page",
                 start_page=page,
-                has_more_extractor=lambda response: response.has_more,
-                items_extractor=lambda response: response.songs,
+                has_more_extractor=lambda r: r.has_more,
             ),
-        )
+        ).with_extractor(lambda r: r.songs)
 
     def get_recommend_songlist(self, page: int = 1, num: int = 25):
         """获取推荐歌单.
@@ -131,13 +125,12 @@ class RecommendApi(ApiModule):
             "GetRecommendFeed",
             data,
             response_model=RecommendSonglistResponse,
-            pager_strategy=CursorStrategy[Any, RecommendSonglistResponse, SongList](
+            pager_strategy=CursorStrategy[RecommendSonglistResponse](
                 cursor_key="From",
-                has_more_extractor=lambda response: response.has_more,
-                cursor_extractor=lambda response: response.from_limit,
-                items_extractor=lambda response: response.songlists,
+                has_more_extractor=lambda r: r.has_more,
+                cursor_extractor=lambda r: r.from_limit,
             ),
-        )
+        ).with_extractor(lambda r: r.songlists)
 
     def get_recommend_newsong(self, type: int = 5):  # noqa: A002
         """获取推荐新歌.

--- a/qqmusic_api/modules/recommend.py
+++ b/qqmusic_api/modules/recommend.py
@@ -29,9 +29,9 @@ class RecommendApi(ApiModule):
 
         Args:
             page: 页码.
-            direction: 翻页方向, 0=首屏, 1=向后翻页.
-            s_num: 已拉取的楼层数量累加值.
-            v_cache: 已经拉取过的楼层 ID 缓存列表.
+            direction: 刷新方向.
+            s_num: 已加载的卡片数量.
+            v_cache: 已曝光的卡片 ID 缓存, 防止重复推荐.
         """
         data: dict[str, Any] = {
             "direction": direction,
@@ -113,7 +113,7 @@ class RecommendApi(ApiModule):
             pager_strategy=PageStrategy[Any, RadarRecommendResponse, Song](
                 page_key="Page",
                 start_page=page,
-                has_more_extractor=lambda response: bool(response.has_more),
+                has_more_extractor=lambda response: response.has_more,
                 items_extractor=lambda response: response.songs,
             ),
         )
@@ -133,7 +133,7 @@ class RecommendApi(ApiModule):
             response_model=RecommendSonglistResponse,
             pager_strategy=CursorStrategy[Any, RecommendSonglistResponse, SongList](
                 cursor_key="From",
-                has_more_extractor=lambda response: bool(response.has_more),
+                has_more_extractor=lambda response: response.has_more,
                 cursor_extractor=lambda response: response.from_limit,
                 items_extractor=lambda response: response.songlists,
             ),

--- a/qqmusic_api/modules/recommend.py
+++ b/qqmusic_api/modules/recommend.py
@@ -60,6 +60,7 @@ class RecommendApi(ApiModule):
             response_model=RecommendFeedCardResponse,
             pager_strategy=MultiFieldContinuationStrategy[Any, RecommendFeedCardResponse](
                 _build_home_feed_next_params,
+                items_extractor=lambda response: response.shelves,
                 context_name="recommend_home_feed",
             ),
         )
@@ -106,6 +107,7 @@ class RecommendApi(ApiModule):
                 page_key="Page",
                 start_page=page,
                 has_more_extractor=lambda response: bool(response.has_more),
+                items_extractor=lambda response: response.songs,
             ),
         )
 
@@ -126,6 +128,7 @@ class RecommendApi(ApiModule):
                 cursor_key="From",
                 has_more_extractor=lambda response: bool(response.has_more),
                 cursor_extractor=lambda response: response.from_limit,
+                items_extractor=lambda response: response.songlists,
             ),
         )
 

--- a/qqmusic_api/modules/search.py
+++ b/qqmusic_api/modules/search.py
@@ -5,7 +5,7 @@ from typing import Any, Literal, cast, overload
 
 from ..core import Platform
 from ..core.pagination import MultiFieldContinuationStrategy, PageStrategy
-from ..core.request import PaginatedRequest
+from ..core.request import ItemPaginatedRequest, PaginatedRequest
 from ..models.search import (
     AlbumSearch,
     GeneralSearchResponse,
@@ -103,7 +103,7 @@ class SearchApi(ApiModule):
         page_start: dict[str, Any] | None = None,
         *,
         highlight: bool = True,
-    ):
+    ) -> PaginatedRequest[GeneralSearchResponse]:
         """综合搜索.
 
         Args:
@@ -156,7 +156,7 @@ class SearchApi(ApiModule):
         searchid: str | None = None,
         *,
         highlight: bool = True,
-    ) -> PaginatedRequest[SearchByTypeResponse, SongSearch]: ...
+    ) -> ItemPaginatedRequest[SearchByTypeResponse, SongSearch]: ...
 
     @overload
     def search_by_type(
@@ -169,7 +169,7 @@ class SearchApi(ApiModule):
         searchid: str | None = None,
         *,
         highlight: bool = True,
-    ) -> PaginatedRequest[SearchByTypeResponse, SingerSearch]: ...
+    ) -> ItemPaginatedRequest[SearchByTypeResponse, SingerSearch]: ...
 
     @overload
     def search_by_type(
@@ -182,7 +182,7 @@ class SearchApi(ApiModule):
         searchid: str | None = None,
         *,
         highlight: bool = True,
-    ) -> PaginatedRequest[SearchByTypeResponse, AlbumSearch]: ...
+    ) -> ItemPaginatedRequest[SearchByTypeResponse, AlbumSearch]: ...
 
     @overload
     def search_by_type(
@@ -195,7 +195,7 @@ class SearchApi(ApiModule):
         searchid: str | None = None,
         *,
         highlight: bool = True,
-    ) -> PaginatedRequest[SearchByTypeResponse, SongListSearch]: ...
+    ) -> ItemPaginatedRequest[SearchByTypeResponse, SongListSearch]: ...
 
     @overload
     def search_by_type(
@@ -208,7 +208,7 @@ class SearchApi(ApiModule):
         searchid: str | None = None,
         *,
         highlight: bool = True,
-    ) -> PaginatedRequest[SearchByTypeResponse, MvSearch]: ...
+    ) -> ItemPaginatedRequest[SearchByTypeResponse, MvSearch]: ...
 
     @overload
     def search_by_type(
@@ -221,7 +221,7 @@ class SearchApi(ApiModule):
         searchid: str | None = None,
         *,
         highlight: bool = True,
-    ) -> PaginatedRequest[SearchByTypeResponse, dict[str, Any]]: ...
+    ) -> ItemPaginatedRequest[SearchByTypeResponse, dict[str, Any]]: ...
 
     @overload
     def search_by_type(
@@ -234,7 +234,7 @@ class SearchApi(ApiModule):
         searchid: str | None = None,
         *,
         highlight: bool = True,
-    ) -> PaginatedRequest[SearchByTypeResponse, SearchByTypeItem]: ...
+    ) -> ItemPaginatedRequest[SearchByTypeResponse, SearchByTypeItem]: ...
 
     def search_by_type(
         self,

--- a/qqmusic_api/modules/search.py
+++ b/qqmusic_api/modules/search.py
@@ -129,7 +129,7 @@ class SearchApi(ApiModule):
             "do_search_v2",
             param,
             response_model=GeneralSearchResponse,
-            pager_strategy=MultiFieldContinuationStrategy(
+            pager_strategy=MultiFieldContinuationStrategy[GeneralSearchResponse](
                 lambda params, response: {
                     **params,
                     "searchid": response.searchid,

--- a/qqmusic_api/modules/search.py
+++ b/qqmusic_api/modules/search.py
@@ -1,10 +1,11 @@
 """搜索相关 API."""
 
 from enum import IntEnum
-from typing import Any, cast
+from typing import Any, Literal, cast, overload
 
 from ..core import Platform
 from ..core.pagination import MultiFieldContinuationStrategy, PageStrategy
+from ..core.request import PaginatedRequest
 from ..models.search import (
     AlbumSearch,
     GeneralSearchResponse,
@@ -141,6 +142,99 @@ class SearchApi(ApiModule):
                 context_name="general_search",
             ),
         )
+
+    @overload
+    def search_by_type(
+        self,
+        keyword: str,
+        search_type: Literal[
+            SearchType.SONG, 0, SearchType.LYRIC, 7, SearchType.AUDIO, 18, SearchType.RINGTONE, 10
+        ] = SearchType.SONG,
+        num: int = 10,
+        page: int = 1,
+        selectors: list[SearchSelector] | None = None,
+        searchid: str | None = None,
+        *,
+        highlight: bool = True,
+    ) -> PaginatedRequest[SearchByTypeResponse, SongSearch]: ...
+
+    @overload
+    def search_by_type(
+        self,
+        keyword: str,
+        search_type: Literal[SearchType.SINGER, 1],
+        num: int = 10,
+        page: int = 1,
+        selectors: list[SearchSelector] | None = None,
+        searchid: str | None = None,
+        *,
+        highlight: bool = True,
+    ) -> PaginatedRequest[SearchByTypeResponse, SingerSearch]: ...
+
+    @overload
+    def search_by_type(
+        self,
+        keyword: str,
+        search_type: Literal[SearchType.ALBUM, 2, SearchType.AUDIO_ALBUM, 15],
+        num: int = 10,
+        page: int = 1,
+        selectors: list[SearchSelector] | None = None,
+        searchid: str | None = None,
+        *,
+        highlight: bool = True,
+    ) -> PaginatedRequest[SearchByTypeResponse, AlbumSearch]: ...
+
+    @overload
+    def search_by_type(
+        self,
+        keyword: str,
+        search_type: Literal[SearchType.SONGLIST, 3],
+        num: int = 10,
+        page: int = 1,
+        selectors: list[SearchSelector] | None = None,
+        searchid: str | None = None,
+        *,
+        highlight: bool = True,
+    ) -> PaginatedRequest[SearchByTypeResponse, SongListSearch]: ...
+
+    @overload
+    def search_by_type(
+        self,
+        keyword: str,
+        search_type: Literal[SearchType.MV, 4],
+        num: int = 10,
+        page: int = 1,
+        selectors: list[SearchSelector] | None = None,
+        searchid: str | None = None,
+        *,
+        highlight: bool = True,
+    ) -> PaginatedRequest[SearchByTypeResponse, MvSearch]: ...
+
+    @overload
+    def search_by_type(
+        self,
+        keyword: str,
+        search_type: Literal[SearchType.USER, 8],
+        num: int = 10,
+        page: int = 1,
+        selectors: list[SearchSelector] | None = None,
+        searchid: str | None = None,
+        *,
+        highlight: bool = True,
+    ) -> PaginatedRequest[SearchByTypeResponse, dict[str, Any]]: ...
+
+    @overload
+    def search_by_type(
+        self,
+        keyword: str,
+        search_type: int | SearchType = SearchType.SONG,
+        num: int = 10,
+        page: int = 1,
+        selectors: list[SearchSelector] | None = None,
+        searchid: str | None = None,
+        *,
+        highlight: bool = True,
+    ) -> PaginatedRequest[SearchByTypeResponse, SearchByTypeItem]: ...
 
     def search_by_type(
         self,

--- a/qqmusic_api/modules/search.py
+++ b/qqmusic_api/modules/search.py
@@ -5,9 +5,20 @@ from typing import Any, cast
 
 from ..core import Platform
 from ..core.pagination import MultiFieldContinuationStrategy, PageStrategy
-from ..models.search import GeneralSearchResponse, SearchByTypeResponse, SearchSelector
+from ..models.search import (
+    AlbumSearch,
+    GeneralSearchResponse,
+    MvSearch,
+    SearchByTypeResponse,
+    SearchSelector,
+    SingerSearch,
+    SongListSearch,
+    SongSearch,
+)
 from ..utils import get_searchID
 from ._base import ApiModule
+
+SearchByTypeItem = SongSearch | SingerSearch | AlbumSearch | SongListSearch | MvSearch | dict[str, Any]
 
 
 class SearchType(IntEnum):
@@ -127,14 +138,6 @@ class SearchApi(ApiModule):
                     "page_start": response.nextpage_start,
                 },
                 has_more_extractor=lambda response: response.nextpage != -1,
-                items_extractor=lambda response: [
-                    *(response.song.items if response.song else []),
-                    *(response.singer.items if response.singer else []),
-                    *(response.album.items if response.album else []),
-                    *(response.songlist.items if response.songlist else []),
-                    *(response.mv.items if response.mv else []),
-                    *(response.audio.items if response.audio else []),
-                ],
                 context_name="general_search",
             ),
         )
@@ -184,7 +187,7 @@ class SearchApi(ApiModule):
             },
             platform=Platform.ANDROID,
             response_model=SearchByTypeResponse,
-            pager_strategy=PageStrategy[Any, SearchByTypeResponse](
+            pager_strategy=PageStrategy[Any, SearchByTypeResponse, SearchByTypeItem](
                 page_key="page_num",
                 page_size=num,
                 start_page=page,

--- a/qqmusic_api/modules/search.py
+++ b/qqmusic_api/modules/search.py
@@ -4,7 +4,7 @@ from enum import IntEnum
 from typing import Any, cast
 
 from ..core import Platform
-from ..core.pagination import MultiFieldContinuationStrategy, PagerMeta, PageStrategy, ResponseAdapter
+from ..core.pagination import MultiFieldContinuationStrategy, PageStrategy
 from ..models.search import GeneralSearchResponse, SearchByTypeResponse, SearchSelector
 from ..utils import get_searchID
 from ._base import ApiModule
@@ -119,20 +119,15 @@ class SearchApi(ApiModule):
             "do_search_v2",
             param,
             response_model=GeneralSearchResponse,
-            pager_meta=PagerMeta(
-                strategy=MultiFieldContinuationStrategy(
-                    lambda params, response, adapter: {
-                        **cast("dict[str, Any]", params),
-                        "searchid": response.searchid,
-                        "page_id": response.nextpage,
-                        "page_start": cast("dict[str, Any]", adapter.get_cursor(response)),
-                    },
-                    context_name="general_search",
-                ),
-                adapter=ResponseAdapter(
-                    has_more_flag=lambda response: response.nextpage != -1,
-                    cursor="nextpage_start",
-                ),
+            pager_strategy=MultiFieldContinuationStrategy[Any, GeneralSearchResponse](
+                lambda params, response: {
+                    **cast("dict[str, Any]", params),
+                    "searchid": response.searchid,
+                    "page_id": response.nextpage,
+                    "page_start": response.nextpage_start,
+                },
+                has_more_extractor=lambda response: response.nextpage != -1,
+                context_name="general_search",
             ),
         )
 
@@ -181,11 +176,11 @@ class SearchApi(ApiModule):
             },
             platform=Platform.ANDROID,
             response_model=SearchByTypeResponse,
-            pager_meta=PagerMeta(
-                strategy=PageStrategy(page_key="page_num", page_size=num, start_page=page),
-                adapter=ResponseAdapter(
-                    has_more_flag=lambda r: getattr(r, "nextpage", -1) != -1,
-                    total="total_num",
-                ),
+            pager_strategy=PageStrategy[Any, SearchByTypeResponse](
+                page_key="page_num",
+                page_size=num,
+                start_page=page,
+                has_more_extractor=lambda r: getattr(r, "nextpage", -1) != -1,
+                total_extractor=lambda r: getattr(r, "total_num", None),
             ),
         )

--- a/qqmusic_api/modules/search.py
+++ b/qqmusic_api/modules/search.py
@@ -127,6 +127,14 @@ class SearchApi(ApiModule):
                     "page_start": response.nextpage_start,
                 },
                 has_more_extractor=lambda response: response.nextpage != -1,
+                items_extractor=lambda response: [
+                    *(response.song.items if response.song else []),
+                    *(response.singer.items if response.singer else []),
+                    *(response.album.items if response.album else []),
+                    *(response.songlist.items if response.songlist else []),
+                    *(response.mv.items if response.mv else []),
+                    *(response.audio.items if response.audio else []),
+                ],
                 context_name="general_search",
             ),
         )
@@ -182,5 +190,8 @@ class SearchApi(ApiModule):
                 start_page=page,
                 has_more_extractor=lambda r: getattr(r, "nextpage", -1) != -1,
                 total_extractor=lambda r: getattr(r, "total_num", None),
+                items_extractor=lambda r: (
+                    r.song or r.singer or r.album or r.songlist or r.mv or r.user or r.audio_alum or []
+                ),
             ),
         )

--- a/qqmusic_api/modules/search.py
+++ b/qqmusic_api/modules/search.py
@@ -188,8 +188,8 @@ class SearchApi(ApiModule):
                 page_key="page_num",
                 page_size=num,
                 start_page=page,
-                has_more_extractor=lambda r: getattr(r, "nextpage", -1) != -1,
-                total_extractor=lambda r: getattr(r, "total_num", None),
+                has_more_extractor=lambda r: r.nextpage != -1,
+                total_extractor=lambda r: r.total_num,
                 items_extractor=lambda r: (
                     r.song or r.singer or r.album or r.songlist or r.mv or r.user or r.audio_alum or []
                 ),

--- a/qqmusic_api/modules/search.py
+++ b/qqmusic_api/modules/search.py
@@ -1,7 +1,7 @@
 """搜索相关 API."""
 
 from enum import IntEnum
-from typing import Any, Literal, cast, overload
+from typing import Any, Literal, overload
 
 from ..core import Platform
 from ..core.pagination import MultiFieldContinuationStrategy, PageStrategy
@@ -18,8 +18,6 @@ from ..models.search import (
 )
 from ..utils import get_searchID
 from ._base import ApiModule
-
-SearchByTypeItem = SongSearch | SingerSearch | AlbumSearch | SongListSearch | MvSearch | dict[str, Any]
 
 
 class SearchType(IntEnum):
@@ -131,9 +129,9 @@ class SearchApi(ApiModule):
             "do_search_v2",
             param,
             response_model=GeneralSearchResponse,
-            pager_strategy=MultiFieldContinuationStrategy[Any, GeneralSearchResponse](
+            pager_strategy=MultiFieldContinuationStrategy(
                 lambda params, response: {
-                    **cast("dict[str, Any]", params),
+                    **params,
                     "searchid": response.searchid,
                     "page_id": response.nextpage,
                     "page_start": response.nextpage_start,
@@ -223,19 +221,6 @@ class SearchApi(ApiModule):
         highlight: bool = True,
     ) -> ItemPaginatedRequest[SearchByTypeResponse, dict[str, Any]]: ...
 
-    @overload
-    def search_by_type(
-        self,
-        keyword: str,
-        search_type: int | SearchType = SearchType.SONG,
-        num: int = 10,
-        page: int = 1,
-        selectors: list[SearchSelector] | None = None,
-        searchid: str | None = None,
-        *,
-        highlight: bool = True,
-    ) -> ItemPaginatedRequest[SearchByTypeResponse, SearchByTypeItem]: ...
-
     def search_by_type(
         self,
         keyword: str,
@@ -261,6 +246,19 @@ class SearchApi(ApiModule):
             highlight: 是否高亮关键词.
         """
         normalized_search_type = int(SearchType(search_type))
+
+        def _extract_items(
+            r: SearchByTypeResponse,
+        ) -> (
+            list[SongSearch]
+            | list[SingerSearch]
+            | list[AlbumSearch]
+            | list[SongListSearch]
+            | list[MvSearch]
+            | list[dict[str, Any]]
+        ):
+            return r.song or r.singer or r.album or r.songlist or r.mv or r.user or r.audio_alum or []
+
         return self._build_request(
             "music.search.SearchCgiService",
             "DoSearchForQQMusicMobile",
@@ -281,14 +279,11 @@ class SearchApi(ApiModule):
             },
             platform=Platform.ANDROID,
             response_model=SearchByTypeResponse,
-            pager_strategy=PageStrategy[Any, SearchByTypeResponse, SearchByTypeItem](
+            pager_strategy=PageStrategy[SearchByTypeResponse](
                 page_key="page_num",
                 page_size=num,
                 start_page=page,
                 has_more_extractor=lambda r: r.nextpage != -1,
                 total_extractor=lambda r: r.total_num,
-                items_extractor=lambda r: (
-                    r.song or r.singer or r.album or r.songlist or r.mv or r.user or r.audio_alum or []
-                ),
             ),
-        )
+        ).with_extractor(_extract_items)

--- a/qqmusic_api/modules/singer.py
+++ b/qqmusic_api/modules/singer.py
@@ -182,8 +182,7 @@ class SingerApi(ApiModule):
                 lambda params, response: (
                     None
                     if not response.singerlist
-                    or cast("dict[str, int]", params)["sin"] + len(response.singerlist)
-                    >= (getattr(response, "total", 0) or 0)
+                    or cast("dict[str, int]", params)["sin"] + len(response.singerlist) >= (response.total or 0)
                     else {
                         **cast("dict[str, int]", params),
                         "sin": cast("dict[str, int]", params)["sin"] + len(response.singerlist),

--- a/qqmusic_api/modules/singer.py
+++ b/qqmusic_api/modules/singer.py
@@ -1,15 +1,13 @@
 """歌手相关 API."""
 
 from enum import Enum, IntEnum
-from typing import cast
+from typing import Any, cast
 
 from ..core import Platform
 from ..core.pagination import (
     MultiFieldContinuationStrategy,
     OffsetStrategy,
-    PagerMeta,
     PageStrategy,
-    ResponseAdapter,
 )
 from ..models.singer import (
     HomepageHeaderResponse,
@@ -99,13 +97,13 @@ class IndexType(IntEnum):
     F = 6
     G = 7
     H = 8
-    I = 9  # noqa: E741
+    I = 9
     J = 10
     K = 11
     L = 12
     M = 13
     N = 14
-    O = 15  # noqa: E741
+    O = 15
     P = 16
     Q = 17
     R = 18
@@ -180,22 +178,19 @@ class SingerApi(ApiModule):
                 "cur_page": page,
             },
             response_model=SingerIndexPageResponse,
-            pager_meta=PagerMeta(
-                strategy=MultiFieldContinuationStrategy(
-                    lambda params, response, adapter: (
-                        None
-                        if not response.singerlist
-                        or cast("dict[str, int]", params)["sin"] + len(response.singerlist)
-                        >= (adapter.get_total(response) or 0)
-                        else {
-                            **cast("dict[str, int]", params),
-                            "sin": cast("dict[str, int]", params)["sin"] + len(response.singerlist),
-                            "cur_page": cast("dict[str, int]", params)["cur_page"] + 1,
-                        }
-                    ),
-                    context_name="singer_list_index",
+            pager_strategy=MultiFieldContinuationStrategy[Any, SingerIndexPageResponse](
+                lambda params, response: (
+                    None
+                    if not response.singerlist
+                    or cast("dict[str, int]", params)["sin"] + len(response.singerlist)
+                    >= (getattr(response, "total", 0) or 0)
+                    else {
+                        **cast("dict[str, int]", params),
+                        "sin": cast("dict[str, int]", params)["sin"] + len(response.singerlist),
+                        "cur_page": cast("dict[str, int]", params)["cur_page"] + 1,
+                    }
                 ),
-                adapter=ResponseAdapter(total="total"),
+                context_name="singer_list_index",
             ),
         )
 
@@ -242,9 +237,11 @@ class SingerApi(ApiModule):
                 "Order": 0,
             },
             response_model=HomepageTabDetailResponse,
-            pager_meta=PagerMeta(
-                strategy=PageStrategy(page_key="PageNum", page_size=num, start_page=page - 1),
-                adapter=ResponseAdapter(has_more_flag="has_more"),
+            pager_strategy=PageStrategy[Any, HomepageTabDetailResponse](
+                page_key="PageNum",
+                page_size=num,
+                start_page=page - 1,
+                has_more_extractor=lambda response: bool(response.has_more),
             ),
         )
 
@@ -288,9 +285,11 @@ class SingerApi(ApiModule):
             method="GetSingerSongList",
             param={"singerMid": mid, "order": 1, "number": num, "begin": (page - 1) * num},
             response_model=SingerSongListResponse,
-            pager_meta=PagerMeta(
-                strategy=OffsetStrategy(offset_key="begin", page_size_key="number"),
-                adapter=ResponseAdapter(total="total_num", count=lambda response: len(response.song_list)),
+            pager_strategy=OffsetStrategy[Any, SingerSongListResponse](
+                offset_key="begin",
+                page_size_key="number",
+                total_extractor=lambda response: response.total_num,
+                count_extractor=lambda response: len(response.song_list),
             ),
         )
 
@@ -307,9 +306,11 @@ class SingerApi(ApiModule):
             method="GetAlbumList",
             param={"singerMid": mid, "order": 1, "number": num, "begin": (page - 1) * num},
             response_model=SingerAlbumListResponse,
-            pager_meta=PagerMeta(
-                strategy=OffsetStrategy(offset_key="begin", page_size_key="number"),
-                adapter=ResponseAdapter(total="total", count=lambda response: len(response.album_list)),
+            pager_strategy=OffsetStrategy[Any, SingerAlbumListResponse](
+                offset_key="begin",
+                page_size_key="number",
+                total_extractor=lambda response: response.total,
+                count_extractor=lambda response: len(response.album_list),
             ),
         )
 
@@ -326,8 +327,10 @@ class SingerApi(ApiModule):
             method="GetSingerMvList",
             param={"singermid": mid, "order": 1, "count": num, "start": (page - 1) * num},
             response_model=SingerMvListResponse,
-            pager_meta=PagerMeta(
-                strategy=OffsetStrategy(offset_key="start", page_size_key="count"),
-                adapter=ResponseAdapter(total="total", count=lambda response: len(response.mv_list)),
+            pager_strategy=OffsetStrategy[Any, SingerMvListResponse](
+                offset_key="start",
+                page_size_key="count",
+                total_extractor=lambda response: response.total,
+                count_extractor=lambda response: len(response.mv_list),
             ),
         )

--- a/qqmusic_api/modules/singer.py
+++ b/qqmusic_api/modules/singer.py
@@ -1,7 +1,7 @@
 """歌手相关 API."""
 
 from enum import Enum, IntEnum
-from typing import Any, cast
+from typing import cast
 
 from ..core import Platform
 from ..core.pagination import (
@@ -9,7 +9,6 @@ from ..core.pagination import (
     OffsetStrategy,
     PageStrategy,
 )
-from ..models.base import MV, Album, Singer, Song
 from ..models.singer import (
     HomepageHeaderResponse,
     HomepageTabDetailResponse,
@@ -179,7 +178,7 @@ class SingerApi(ApiModule):
                 "cur_page": page,
             },
             response_model=SingerIndexPageResponse,
-            pager_strategy=MultiFieldContinuationStrategy[Any, SingerIndexPageResponse, Singer](
+            pager_strategy=MultiFieldContinuationStrategy(
                 lambda params, response: (
                     None
                     if not response.singerlist
@@ -190,10 +189,9 @@ class SingerApi(ApiModule):
                         "cur_page": cast("dict[str, int]", params)["cur_page"] + 1,
                     }
                 ),
-                items_extractor=lambda response: response.singerlist,
                 context_name="singer_list_index",
             ),
-        )
+        ).with_extractor(lambda r: r.singerlist)
 
     def get_info(self, mid: str):
         """获取歌手主页基本信息.
@@ -238,7 +236,7 @@ class SingerApi(ApiModule):
                 "Order": 0,
             },
             response_model=HomepageTabDetailResponse,
-            pager_strategy=PageStrategy[Any, HomepageTabDetailResponse](
+            pager_strategy=PageStrategy[HomepageTabDetailResponse](
                 page_key="PageNum",
                 page_size=num,
                 start_page=page - 1,
@@ -286,14 +284,13 @@ class SingerApi(ApiModule):
             method="GetSingerSongList",
             param={"singerMid": mid, "order": 1, "number": num, "begin": (page - 1) * num},
             response_model=SingerSongListResponse,
-            pager_strategy=OffsetStrategy[Any, SingerSongListResponse, Song](
+            pager_strategy=OffsetStrategy[SingerSongListResponse](
                 offset_key="begin",
                 page_size_key="number",
-                total_extractor=lambda response: response.total_num,
-                count_extractor=lambda response: len(response.song_list),
-                items_extractor=lambda response: response.song_list,
+                total_extractor=lambda r: r.total_num,
+                count_extractor=lambda r: len(r.song_list),
             ),
-        )
+        ).with_extractor(lambda response: response.song_list)
 
     def get_album_list(self, mid: str, num: int = 10, page: int = 1):
         """获取歌手的专辑列表.
@@ -308,14 +305,13 @@ class SingerApi(ApiModule):
             method="GetAlbumList",
             param={"singerMid": mid, "order": 1, "number": num, "begin": (page - 1) * num},
             response_model=SingerAlbumListResponse,
-            pager_strategy=OffsetStrategy[Any, SingerAlbumListResponse, Album](
+            pager_strategy=OffsetStrategy[SingerAlbumListResponse](
                 offset_key="begin",
                 page_size_key="number",
-                total_extractor=lambda response: response.total,
-                count_extractor=lambda response: len(response.album_list),
-                items_extractor=lambda response: response.album_list,
+                total_extractor=lambda r: r.total,
+                count_extractor=lambda r: len(r.album_list),
             ),
-        )
+        ).with_extractor(lambda r: r.album_list)
 
     def get_mv_list(self, mid: str, num: int = 10, page: int = 1):
         """获取歌手 MV 列表数据.
@@ -330,11 +326,10 @@ class SingerApi(ApiModule):
             method="GetSingerMvList",
             param={"singermid": mid, "order": 1, "count": num, "start": (page - 1) * num},
             response_model=SingerMvListResponse,
-            pager_strategy=OffsetStrategy[Any, SingerMvListResponse, MV](
+            pager_strategy=OffsetStrategy[SingerMvListResponse](
                 offset_key="start",
                 page_size_key="count",
-                total_extractor=lambda response: response.total,
-                count_extractor=lambda response: len(response.mv_list),
-                items_extractor=lambda response: response.mv_list,
+                total_extractor=lambda r: r.total,
+                count_extractor=lambda r: len(r.mv_list),
             ),
-        )
+        ).with_extractor(lambda r: r.mv_list)

--- a/qqmusic_api/modules/singer.py
+++ b/qqmusic_api/modules/singer.py
@@ -190,6 +190,7 @@ class SingerApi(ApiModule):
                         "cur_page": cast("dict[str, int]", params)["cur_page"] + 1,
                     }
                 ),
+                items_extractor=lambda response: response.singerlist,
                 context_name="singer_list_index",
             ),
         )
@@ -242,6 +243,9 @@ class SingerApi(ApiModule):
                 page_size=num,
                 start_page=page - 1,
                 has_more_extractor=lambda response: bool(response.has_more),
+                items_extractor=lambda response: (
+                    response.song_tab or response.album_tab or response.video_tab or response.introduction_tab
+                ),
             ),
         )
 
@@ -290,6 +294,7 @@ class SingerApi(ApiModule):
                 page_size_key="number",
                 total_extractor=lambda response: response.total_num,
                 count_extractor=lambda response: len(response.song_list),
+                items_extractor=lambda response: response.song_list,
             ),
         )
 
@@ -311,6 +316,7 @@ class SingerApi(ApiModule):
                 page_size_key="number",
                 total_extractor=lambda response: response.total,
                 count_extractor=lambda response: len(response.album_list),
+                items_extractor=lambda response: response.album_list,
             ),
         )
 
@@ -332,5 +338,6 @@ class SingerApi(ApiModule):
                 page_size_key="count",
                 total_extractor=lambda response: response.total,
                 count_extractor=lambda response: len(response.mv_list),
+                items_extractor=lambda response: response.mv_list,
             ),
         )

--- a/qqmusic_api/modules/singer.py
+++ b/qqmusic_api/modules/singer.py
@@ -9,6 +9,7 @@ from ..core.pagination import (
     OffsetStrategy,
     PageStrategy,
 )
+from ..models.base import MV, Album, Singer, Song
 from ..models.singer import (
     HomepageHeaderResponse,
     HomepageTabDetailResponse,
@@ -178,7 +179,7 @@ class SingerApi(ApiModule):
                 "cur_page": page,
             },
             response_model=SingerIndexPageResponse,
-            pager_strategy=MultiFieldContinuationStrategy[Any, SingerIndexPageResponse](
+            pager_strategy=MultiFieldContinuationStrategy[Any, SingerIndexPageResponse, Singer](
                 lambda params, response: (
                     None
                     if not response.singerlist
@@ -242,9 +243,6 @@ class SingerApi(ApiModule):
                 page_size=num,
                 start_page=page - 1,
                 has_more_extractor=lambda response: bool(response.has_more),
-                items_extractor=lambda response: (
-                    response.song_tab or response.album_tab or response.video_tab or response.introduction_tab
-                ),
             ),
         )
 
@@ -288,7 +286,7 @@ class SingerApi(ApiModule):
             method="GetSingerSongList",
             param={"singerMid": mid, "order": 1, "number": num, "begin": (page - 1) * num},
             response_model=SingerSongListResponse,
-            pager_strategy=OffsetStrategy[Any, SingerSongListResponse](
+            pager_strategy=OffsetStrategy[Any, SingerSongListResponse, Song](
                 offset_key="begin",
                 page_size_key="number",
                 total_extractor=lambda response: response.total_num,
@@ -310,7 +308,7 @@ class SingerApi(ApiModule):
             method="GetAlbumList",
             param={"singerMid": mid, "order": 1, "number": num, "begin": (page - 1) * num},
             response_model=SingerAlbumListResponse,
-            pager_strategy=OffsetStrategy[Any, SingerAlbumListResponse](
+            pager_strategy=OffsetStrategy[Any, SingerAlbumListResponse, Album](
                 offset_key="begin",
                 page_size_key="number",
                 total_extractor=lambda response: response.total,
@@ -332,7 +330,7 @@ class SingerApi(ApiModule):
             method="GetSingerMvList",
             param={"singermid": mid, "order": 1, "count": num, "start": (page - 1) * num},
             response_model=SingerMvListResponse,
-            pager_strategy=OffsetStrategy[Any, SingerMvListResponse](
+            pager_strategy=OffsetStrategy[Any, SingerMvListResponse, MV](
                 offset_key="start",
                 page_size_key="count",
                 total_extractor=lambda response: response.total,

--- a/qqmusic_api/modules/singer.py
+++ b/qqmusic_api/modules/singer.py
@@ -178,11 +178,10 @@ class SingerApi(ApiModule):
                 "cur_page": page,
             },
             response_model=SingerIndexPageResponse,
-            pager_strategy=MultiFieldContinuationStrategy(
+            pager_strategy=MultiFieldContinuationStrategy[SingerIndexPageResponse](
                 lambda params, response: (
                     None
-                    if not response.singerlist
-                    or cast("dict[str, int]", params)["sin"] + len(response.singerlist) >= (response.total or 0)
+                    if not response.singerlist or params["sin"] + len(response.singerlist) >= (response.total or 0)
                     else {
                         **cast("dict[str, int]", params),
                         "sin": cast("dict[str, int]", params)["sin"] + len(response.singerlist),

--- a/qqmusic_api/modules/song.py
+++ b/qqmusic_api/modules/song.py
@@ -377,7 +377,7 @@ class SongApi(ApiModule):
             method="GetRelatedPlaylist",
             param={"songid": songid, "vecPlaylist": last or []},
             response_model=GetRelatedSonglistResponse,
-            refresh_strategy=BatchRefreshStrategy[GetRelatedSonglistResponse](
+            pager_strategy=BatchRefreshStrategy[GetRelatedSonglistResponse](
                 refresh_key="vecPlaylist",
                 has_more_extractor=lambda r: bool(r.has_more),
                 cursor_extractor=lambda r: [playlist.id for playlist in r.songlist] if r.songlist else None,
@@ -396,7 +396,7 @@ class SongApi(ApiModule):
             method="GetSongRelatedMv",
             param={"songid": str(songid), "songtype": 1, "lastmvid": last_mvid or 0},
             response_model=GetRelatedMvResponse,
-            refresh_strategy=BatchRefreshStrategy[GetRelatedMvResponse](
+            pager_strategy=BatchRefreshStrategy[GetRelatedMvResponse](
                 refresh_key="lastmvid",
                 has_more_extractor=lambda r: bool(r.has_more),
                 cursor_extractor=lambda r: r.mv[-1].id if r.mv else None,

--- a/qqmusic_api/modules/song.py
+++ b/qqmusic_api/modules/song.py
@@ -6,7 +6,6 @@ from typing import Any, NamedTuple
 from qqmusic_api import Platform
 
 from ..core.pagination import BatchRefreshStrategy
-from ..models.base import MV, SongList
 from ..models.request import Credential
 from ..models.song import (
     GetCdnDispatchResponse,
@@ -378,15 +377,12 @@ class SongApi(ApiModule):
             method="GetRelatedPlaylist",
             param={"songid": songid, "vecPlaylist": last or []},
             response_model=GetRelatedSonglistResponse,
-            refresh_strategy=BatchRefreshStrategy[Any, GetRelatedSonglistResponse, SongList](
+            refresh_strategy=BatchRefreshStrategy[GetRelatedSonglistResponse](
                 refresh_key="vecPlaylist",
-                has_more_extractor=lambda response: bool(response.has_more),
-                cursor_extractor=lambda response: (
-                    [playlist.id for playlist in response.songlist] if response.songlist else None
-                ),
-                items_extractor=lambda response: response.songlist,
+                has_more_extractor=lambda r: bool(r.has_more),
+                cursor_extractor=lambda r: [playlist.id for playlist in r.songlist] if r.songlist else None,
             ),
-        )
+        ).with_extractor(lambda r: r.songlist)
 
     def get_related_mv(self, songid: int, last_mvid: str | None = None):
         """获取歌曲相关 MV.
@@ -400,13 +396,12 @@ class SongApi(ApiModule):
             method="GetSongRelatedMv",
             param={"songid": str(songid), "songtype": 1, "lastmvid": last_mvid or 0},
             response_model=GetRelatedMvResponse,
-            refresh_strategy=BatchRefreshStrategy[Any, GetRelatedMvResponse, MV](
+            refresh_strategy=BatchRefreshStrategy[GetRelatedMvResponse](
                 refresh_key="lastmvid",
-                has_more_extractor=lambda response: bool(response.has_more),
-                cursor_extractor=lambda response: response.mv[-1].id if response.mv else None,
-                items_extractor=lambda response: response.mv,
+                has_more_extractor=lambda r: bool(r.has_more),
+                cursor_extractor=lambda r: r.mv[-1].id if r.mv else None,
             ),
-        )
+        ).with_extractor(lambda r: r.mv)
 
     def get_other_version(self, value: int | str):
         """获取歌曲其他版本.

--- a/qqmusic_api/modules/song.py
+++ b/qqmusic_api/modules/song.py
@@ -383,6 +383,7 @@ class SongApi(ApiModule):
                 cursor_extractor=lambda response: (
                     [playlist.id for playlist in response.songlist] if response.songlist else None
                 ),
+                items_extractor=lambda response: response.songlist,
             ),
         )
 
@@ -402,6 +403,7 @@ class SongApi(ApiModule):
                 refresh_key="lastmvid",
                 has_more_extractor=lambda response: bool(response.has_more),
                 cursor_extractor=lambda response: response.mv[-1].id if response.mv else None,
+                items_extractor=lambda response: response.mv,
             ),
         )
 

--- a/qqmusic_api/modules/song.py
+++ b/qqmusic_api/modules/song.py
@@ -6,6 +6,7 @@ from typing import Any, NamedTuple
 from qqmusic_api import Platform
 
 from ..core.pagination import BatchRefreshStrategy
+from ..models.base import MV, SongList
 from ..models.request import Credential
 from ..models.song import (
     GetCdnDispatchResponse,
@@ -377,7 +378,7 @@ class SongApi(ApiModule):
             method="GetRelatedPlaylist",
             param={"songid": songid, "vecPlaylist": last or []},
             response_model=GetRelatedSonglistResponse,
-            refresh_strategy=BatchRefreshStrategy[Any, GetRelatedSonglistResponse](
+            refresh_strategy=BatchRefreshStrategy[Any, GetRelatedSonglistResponse, SongList](
                 refresh_key="vecPlaylist",
                 has_more_extractor=lambda response: bool(response.has_more),
                 cursor_extractor=lambda response: (
@@ -399,7 +400,7 @@ class SongApi(ApiModule):
             method="GetSongRelatedMv",
             param={"songid": str(songid), "songtype": 1, "lastmvid": last_mvid or 0},
             response_model=GetRelatedMvResponse,
-            refresh_strategy=BatchRefreshStrategy[Any, GetRelatedMvResponse](
+            refresh_strategy=BatchRefreshStrategy[Any, GetRelatedMvResponse, MV](
                 refresh_key="lastmvid",
                 has_more_extractor=lambda response: bool(response.has_more),
                 cursor_extractor=lambda response: response.mv[-1].id if response.mv else None,

--- a/qqmusic_api/modules/song.py
+++ b/qqmusic_api/modules/song.py
@@ -5,7 +5,7 @@ from typing import Any, NamedTuple
 
 from qqmusic_api import Platform
 
-from ..core.pagination import BatchRefreshStrategy, RefreshMeta, ResponseAdapter
+from ..core.pagination import BatchRefreshStrategy
 from ..models.request import Credential
 from ..models.song import (
     GetCdnDispatchResponse,
@@ -377,13 +377,11 @@ class SongApi(ApiModule):
             method="GetRelatedPlaylist",
             param={"songid": songid, "vecPlaylist": last or []},
             response_model=GetRelatedSonglistResponse,
-            refresh_meta=RefreshMeta(
-                strategy=BatchRefreshStrategy(refresh_key="vecPlaylist"),
-                adapter=ResponseAdapter(
-                    has_more_flag="has_more",
-                    cursor=lambda response: (
-                        [playlist.id for playlist in response.songlist] if response.songlist else None
-                    ),
+            refresh_strategy=BatchRefreshStrategy[Any, GetRelatedSonglistResponse](
+                refresh_key="vecPlaylist",
+                has_more_extractor=lambda response: bool(response.has_more),
+                cursor_extractor=lambda response: (
+                    [playlist.id for playlist in response.songlist] if response.songlist else None
                 ),
             ),
         )
@@ -400,12 +398,10 @@ class SongApi(ApiModule):
             method="GetSongRelatedMv",
             param={"songid": str(songid), "songtype": 1, "lastmvid": last_mvid or 0},
             response_model=GetRelatedMvResponse,
-            refresh_meta=RefreshMeta(
-                strategy=BatchRefreshStrategy(refresh_key="lastmvid"),
-                adapter=ResponseAdapter(
-                    has_more_flag="has_more",
-                    cursor=lambda response: response.mv[-1].id if response.mv else None,
-                ),
+            refresh_strategy=BatchRefreshStrategy[Any, GetRelatedMvResponse](
+                refresh_key="lastmvid",
+                has_more_extractor=lambda response: bool(response.has_more),
+                cursor_extractor=lambda response: response.mv[-1].id if response.mv else None,
             ),
         )
 

--- a/qqmusic_api/modules/songlist.py
+++ b/qqmusic_api/modules/songlist.py
@@ -1,10 +1,7 @@
 """歌单相关 API."""
 
-from typing import Any
-
 from ..core import CgiApiException
 from ..core.pagination import OffsetStrategy
-from ..models.base import Song
 from ..models.request import Credential
 from ..models.songlist import CreateDeleteSonglistResp, GetSonglistDetailResponse
 from ._base import ApiModule
@@ -63,15 +60,14 @@ class SonglistApi(ApiModule):
                 "onlysonglist": onlysong,
             },
             response_model=GetSonglistDetailResponse,
-            pager_strategy=OffsetStrategy[Any, GetSonglistDetailResponse, Song](
+            pager_strategy=OffsetStrategy[GetSonglistDetailResponse](
                 offset_key="song_begin",
                 page_size_key="song_num",
-                has_more_extractor=lambda response: bool(response.hasmore),
-                items_extractor=lambda response: response.songs,
-                total_extractor=lambda response: response.total,
+                has_more_extractor=lambda r: bool(r.hasmore),
+                total_extractor=lambda r: r.total,
                 count_extractor=lambda response: len(response.songs),
             ),
-        )
+        ).with_extractor(lambda r: r.songs)
 
     def create(self, dirname: str, *, credential: Credential | None = None):
         """创建歌单.

--- a/qqmusic_api/modules/songlist.py
+++ b/qqmusic_api/modules/songlist.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from ..core import CgiApiException
 from ..core.pagination import OffsetStrategy
+from ..models.base import Song
 from ..models.request import Credential
 from ..models.songlist import CreateDeleteSonglistResp, GetSonglistDetailResponse
 from ._base import ApiModule
@@ -62,7 +63,7 @@ class SonglistApi(ApiModule):
                 "onlysonglist": onlysong,
             },
             response_model=GetSonglistDetailResponse,
-            pager_strategy=OffsetStrategy[Any, GetSonglistDetailResponse](
+            pager_strategy=OffsetStrategy[Any, GetSonglistDetailResponse, Song](
                 offset_key="song_begin",
                 page_size_key="song_num",
                 has_more_extractor=lambda response: bool(response.hasmore),

--- a/qqmusic_api/modules/songlist.py
+++ b/qqmusic_api/modules/songlist.py
@@ -66,6 +66,7 @@ class SonglistApi(ApiModule):
                 offset_key="song_begin",
                 page_size_key="song_num",
                 has_more_extractor=lambda response: bool(response.hasmore),
+                items_extractor=lambda response: response.songs,
                 total_extractor=lambda response: response.total,
                 count_extractor=lambda response: len(response.songs),
             ),

--- a/qqmusic_api/modules/songlist.py
+++ b/qqmusic_api/modules/songlist.py
@@ -1,7 +1,9 @@
 """歌单相关 API."""
 
+from typing import Any
+
 from ..core import CgiApiException
-from ..core.pagination import OffsetStrategy, PagerMeta, ResponseAdapter
+from ..core.pagination import OffsetStrategy
 from ..models.request import Credential
 from ..models.songlist import CreateDeleteSonglistResp, GetSonglistDetailResponse
 from ._base import ApiModule
@@ -60,13 +62,12 @@ class SonglistApi(ApiModule):
                 "onlysonglist": onlysong,
             },
             response_model=GetSonglistDetailResponse,
-            pager_meta=PagerMeta(
-                strategy=OffsetStrategy(offset_key="song_begin", page_size_key="song_num"),
-                adapter=ResponseAdapter(
-                    has_more_flag="hasmore",
-                    total="total",
-                    count=lambda response: len(response.songs),
-                ),
+            pager_strategy=OffsetStrategy[Any, GetSonglistDetailResponse](
+                offset_key="song_begin",
+                page_size_key="song_num",
+                has_more_extractor=lambda response: bool(response.hasmore),
+                total_extractor=lambda response: response.total,
+                count_extractor=lambda response: len(response.songs),
             ),
         )
 

--- a/qqmusic_api/modules/top.py
+++ b/qqmusic_api/modules/top.py
@@ -1,6 +1,8 @@
 """排行榜相关 API."""
 
-from ..core.pagination import OffsetStrategy, PagerMeta, ResponseAdapter
+from typing import Any
+
+from ..core.pagination import OffsetStrategy
 from ..models.top import TopCategoryResponse, TopDetailResponse
 from ._base import ApiModule
 
@@ -47,11 +49,10 @@ class TopApi(ApiModule):
             param=param,
             preserve_bool=tag,
             response_model=TopDetailResponse,
-            pager_meta=PagerMeta(
-                strategy=OffsetStrategy(offset_key="offset", page_size_key="num"),
-                adapter=ResponseAdapter(
-                    total=lambda response: response.info.total_num,
-                    count=lambda response: len(response.songs),
-                ),
+            pager_strategy=OffsetStrategy[Any, TopDetailResponse](
+                offset_key="offset",
+                page_size_key="num",
+                total_extractor=lambda response: response.info.total_num,
+                count_extractor=lambda response: len(response.songs),
             ),
         )

--- a/qqmusic_api/modules/top.py
+++ b/qqmusic_api/modules/top.py
@@ -52,6 +52,7 @@ class TopApi(ApiModule):
             pager_strategy=OffsetStrategy[Any, TopDetailResponse](
                 offset_key="offset",
                 page_size_key="num",
+                items_extractor=lambda response: response.songs,
                 total_extractor=lambda response: response.info.total_num,
                 count_extractor=lambda response: len(response.songs),
             ),

--- a/qqmusic_api/modules/top.py
+++ b/qqmusic_api/modules/top.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 from ..core.pagination import OffsetStrategy
+from ..models.base import Song
 from ..models.top import TopCategoryResponse, TopDetailResponse
 from ._base import ApiModule
 
@@ -49,7 +50,7 @@ class TopApi(ApiModule):
             param=param,
             preserve_bool=tag,
             response_model=TopDetailResponse,
-            pager_strategy=OffsetStrategy[Any, TopDetailResponse](
+            pager_strategy=OffsetStrategy[Any, TopDetailResponse, Song](
                 offset_key="offset",
                 page_size_key="num",
                 items_extractor=lambda response: response.songs,

--- a/qqmusic_api/modules/top.py
+++ b/qqmusic_api/modules/top.py
@@ -1,9 +1,6 @@
 """排行榜相关 API."""
 
-from typing import Any
-
 from ..core.pagination import OffsetStrategy
-from ..models.base import Song
 from ..models.top import TopCategoryResponse, TopDetailResponse
 from ._base import ApiModule
 
@@ -50,11 +47,10 @@ class TopApi(ApiModule):
             param=param,
             preserve_bool=tag,
             response_model=TopDetailResponse,
-            pager_strategy=OffsetStrategy[Any, TopDetailResponse, Song](
+            pager_strategy=OffsetStrategy[TopDetailResponse](
                 offset_key="offset",
                 page_size_key="num",
-                items_extractor=lambda response: response.songs,
-                total_extractor=lambda response: response.info.total_num,
-                count_extractor=lambda response: len(response.songs),
+                total_extractor=lambda r: r.info.total_num,
+                count_extractor=lambda r: len(r.songs),
             ),
-        )
+        ).with_extractor(lambda r: r.songs)

--- a/qqmusic_api/modules/user.py
+++ b/qqmusic_api/modules/user.py
@@ -414,6 +414,20 @@ class UserApi(ApiModule):
         param: dict[str, Any] = {"Cmd": cmd, "Page": page}
         if lastid:
             param[lastid_fields[cmd]] = lastid
+
+        def _build_next_params(p: dict[str, Any], r: DislikeListData) -> dict[str, Any] | None:
+            if not (r.singers or r.songs or r.styles):
+                return None
+            next_p = p.copy()
+            next_p["Page"] = next_p["Page"] + 1
+            if r.songs:
+                next_p["SongLastid"] = r.songs[-1].id
+            if r.singers:
+                next_p["SingersLastid"] = r.singers[-1].id
+            if r.styles:
+                next_p["StyleLastid"] = r.styles[-1].id
+            return next_p
+
         return self._build_request(
             module="music.feedback.FeedbackBlack",
             method="GetDislikeList",
@@ -423,17 +437,7 @@ class UserApi(ApiModule):
             response_model=DislikeListData,
             sign=True,
             pager_strategy=MultiFieldContinuationStrategy[DislikeListData](
-                build_next_params=lambda p, r: (
-                    {
-                        **p,
-                        "Page": p["Page"] + 1,
-                        "SongLastid": r.songs[-1].id if r.songs else 0,
-                        "SingersLastid": r.singers[-1].id if r.singers else 0,
-                        "StyleLastid": r.styles[-1].id if r.styles else 0,
-                    }
-                    if (r.singers or r.songs or r.styles)
-                    else None
-                ),
+                build_next_params=_build_next_params,
             ),
         )
 

--- a/qqmusic_api/modules/user.py
+++ b/qqmusic_api/modules/user.py
@@ -101,6 +101,7 @@ class UserApi(ApiModule):
                 offset_key="From",
                 page_size_key="Size",
                 has_more_extractor=lambda response: bool(response.has_more),
+                items_extractor=lambda response: response.users,
                 total_extractor=lambda response: getattr(response, "total", None),
                 count_extractor=lambda response: len(response.users),
             ),
@@ -133,6 +134,7 @@ class UserApi(ApiModule):
                 offset_key="From",
                 page_size_key="Size",
                 has_more_extractor=lambda response: bool(response.has_more),
+                items_extractor=lambda response: response.users,
                 total_extractor=lambda response: getattr(response, "total", None),
                 count_extractor=lambda response: len(response.users),
             ),
@@ -164,6 +166,7 @@ class UserApi(ApiModule):
                 page_size=num,
                 start_page=page - 1,
                 has_more_extractor=lambda response: bool(response.has_more),
+                items_extractor=lambda response: response.friends,
             ),
         )
 
@@ -194,6 +197,7 @@ class UserApi(ApiModule):
                 offset_key="From",
                 page_size_key="Size",
                 has_more_extractor=lambda response: bool(response.has_more),
+                items_extractor=lambda response: response.users,
                 total_extractor=lambda response: getattr(response, "total", None),
                 count_extractor=lambda response: len(response.users),
             ),
@@ -249,6 +253,7 @@ class UserApi(ApiModule):
                 offset_key="song_begin",
                 page_size_key="song_num",
                 has_more_extractor=lambda response: bool(getattr(response, "hasmore", 0)),
+                items_extractor=lambda response: response.songs,
                 total_extractor=lambda response: getattr(response, "total", None),
                 count_extractor=lambda response: len(response.songs),
             ),
@@ -280,6 +285,7 @@ class UserApi(ApiModule):
                 offset_key="offset",
                 page_size_key="size",
                 has_more_extractor=lambda response: bool(getattr(response, "hasmore", 0)),
+                items_extractor=lambda response: response.playlists,
                 total_extractor=lambda response: getattr(response, "total", None),
                 count_extractor=lambda response: len(response.playlists),
             ),
@@ -349,6 +355,7 @@ class UserApi(ApiModule):
                 offset_key="offset",
                 page_size_key="size",
                 has_more_extractor=lambda response: bool(getattr(response, "hasmore", 0)),
+                items_extractor=lambda response: response.albums,
                 total_extractor=lambda response: getattr(response, "total", None),
                 count_extractor=lambda response: len(response.albums),
             ),
@@ -434,6 +441,7 @@ class UserApi(ApiModule):
                     if (r.singers or r.songs or r.styles)
                     else None
                 ),
+                items_extractor=lambda response: response.songs or response.singers or response.styles,
             ),
         )
 

--- a/qqmusic_api/modules/user.py
+++ b/qqmusic_api/modules/user.py
@@ -3,13 +3,19 @@
 from typing import Any, ClassVar, cast
 
 from ..core.pagination import MultiFieldContinuationStrategy, OffsetStrategy, PageStrategy
+from ..models.base import Song
 from ..models.request import Credential
 from ..models.songlist import GetSonglistDetailResponse
 from ..models.user import (
+    DislikeItem,
     DislikeListData,
+    FriendEntry,
+    RelationUser,
     UserCreatedSonglistResponse,
+    UserFavAlbumItem,
     UserFavAlbumResponse,
     UserFavMvResponse,
+    UserFavSonglistItem,
     UserFavSonglistResponse,
     UserFriendListResponse,
     UserHomepageResponse,
@@ -97,10 +103,10 @@ class UserApi(ApiModule):
             credential=credential,
             require_login=True,
             response_model=UserRelationListResponse,
-            pager_strategy=OffsetStrategy[Any, UserRelationListResponse](
+            pager_strategy=OffsetStrategy[Any, UserRelationListResponse, RelationUser](
                 offset_key="From",
                 page_size_key="Size",
-                has_more_extractor=lambda response: bool(response.has_more),
+                has_more_extractor=lambda response: response.has_more,
                 items_extractor=lambda response: response.users,
                 total_extractor=lambda response: response.total,
                 count_extractor=lambda response: len(response.users),
@@ -130,10 +136,10 @@ class UserApi(ApiModule):
             credential=credential,
             require_login=True,
             response_model=UserRelationListResponse,
-            pager_strategy=OffsetStrategy[Any, UserRelationListResponse](
+            pager_strategy=OffsetStrategy[Any, UserRelationListResponse, RelationUser](
                 offset_key="From",
                 page_size_key="Size",
-                has_more_extractor=lambda response: bool(response.has_more),
+                has_more_extractor=lambda response: response.has_more,
                 items_extractor=lambda response: response.users,
                 total_extractor=lambda response: response.total,
                 count_extractor=lambda response: len(response.users),
@@ -161,11 +167,11 @@ class UserApi(ApiModule):
             credential=credential,
             require_login=True,
             response_model=UserFriendListResponse,
-            pager_strategy=PageStrategy[Any, UserFriendListResponse](
+            pager_strategy=PageStrategy[Any, UserFriendListResponse, FriendEntry](
                 page_key="Page",
                 page_size=num,
                 start_page=page - 1,
-                has_more_extractor=lambda response: bool(response.has_more),
+                has_more_extractor=lambda response: response.has_more,
                 items_extractor=lambda response: response.friends,
             ),
         )
@@ -193,10 +199,10 @@ class UserApi(ApiModule):
             credential=credential,
             require_login=True,
             response_model=UserRelationListResponse,
-            pager_strategy=OffsetStrategy[Any, UserRelationListResponse](
+            pager_strategy=OffsetStrategy[Any, UserRelationListResponse, RelationUser](
                 offset_key="From",
                 page_size_key="Size",
-                has_more_extractor=lambda response: bool(response.has_more),
+                has_more_extractor=lambda response: response.has_more,
                 items_extractor=lambda response: response.users,
                 total_extractor=lambda response: response.total,
                 count_extractor=lambda response: len(response.users),
@@ -249,7 +255,7 @@ class UserApi(ApiModule):
             },
             credential=credential,
             response_model=GetSonglistDetailResponse,
-            pager_strategy=OffsetStrategy[Any, GetSonglistDetailResponse](
+            pager_strategy=OffsetStrategy[Any, GetSonglistDetailResponse, Song](
                 offset_key="song_begin",
                 page_size_key="song_num",
                 has_more_extractor=lambda response: bool(response.hasmore),
@@ -281,7 +287,7 @@ class UserApi(ApiModule):
             param={"uin": euin, "offset": (page - 1) * num, "size": num},
             credential=credential,
             response_model=UserFavSonglistResponse,
-            pager_strategy=OffsetStrategy[Any, UserFavSonglistResponse](
+            pager_strategy=OffsetStrategy[Any, UserFavSonglistResponse, UserFavSonglistItem](
                 offset_key="offset",
                 page_size_key="size",
                 has_more_extractor=lambda response: bool(response.hasmore),
@@ -351,7 +357,7 @@ class UserApi(ApiModule):
             param={"euin": euin, "offset": (page - 1) * num, "size": num},
             credential=credential,
             response_model=UserFavAlbumResponse,
-            pager_strategy=OffsetStrategy[Any, UserFavAlbumResponse](
+            pager_strategy=OffsetStrategy[Any, UserFavAlbumResponse, UserFavAlbumItem](
                 offset_key="offset",
                 page_size_key="size",
                 has_more_extractor=lambda response: bool(response.hasmore),
@@ -429,7 +435,7 @@ class UserApi(ApiModule):
             require_login=True,
             response_model=DislikeListData,
             sign=True,
-            pager_strategy=MultiFieldContinuationStrategy[Any, DislikeListData](
+            pager_strategy=MultiFieldContinuationStrategy[Any, DislikeListData, DislikeItem](
                 build_next_params=lambda p, r: (
                     {
                         **cast("dict[str, Any]", p),

--- a/qqmusic_api/modules/user.py
+++ b/qqmusic_api/modules/user.py
@@ -102,7 +102,7 @@ class UserApi(ApiModule):
                 page_size_key="Size",
                 has_more_extractor=lambda response: bool(response.has_more),
                 items_extractor=lambda response: response.users,
-                total_extractor=lambda response: getattr(response, "total", None),
+                total_extractor=lambda response: response.total,
                 count_extractor=lambda response: len(response.users),
             ),
         )
@@ -135,7 +135,7 @@ class UserApi(ApiModule):
                 page_size_key="Size",
                 has_more_extractor=lambda response: bool(response.has_more),
                 items_extractor=lambda response: response.users,
-                total_extractor=lambda response: getattr(response, "total", None),
+                total_extractor=lambda response: response.total,
                 count_extractor=lambda response: len(response.users),
             ),
         )
@@ -198,7 +198,7 @@ class UserApi(ApiModule):
                 page_size_key="Size",
                 has_more_extractor=lambda response: bool(response.has_more),
                 items_extractor=lambda response: response.users,
-                total_extractor=lambda response: getattr(response, "total", None),
+                total_extractor=lambda response: response.total,
                 count_extractor=lambda response: len(response.users),
             ),
         )
@@ -252,9 +252,9 @@ class UserApi(ApiModule):
             pager_strategy=OffsetStrategy[Any, GetSonglistDetailResponse](
                 offset_key="song_begin",
                 page_size_key="song_num",
-                has_more_extractor=lambda response: bool(getattr(response, "hasmore", 0)),
+                has_more_extractor=lambda response: bool(response.hasmore),
                 items_extractor=lambda response: response.songs,
-                total_extractor=lambda response: getattr(response, "total", None),
+                total_extractor=lambda response: response.total,
                 count_extractor=lambda response: len(response.songs),
             ),
         )
@@ -284,9 +284,9 @@ class UserApi(ApiModule):
             pager_strategy=OffsetStrategy[Any, UserFavSonglistResponse](
                 offset_key="offset",
                 page_size_key="size",
-                has_more_extractor=lambda response: bool(getattr(response, "hasmore", 0)),
+                has_more_extractor=lambda response: bool(response.hasmore),
                 items_extractor=lambda response: response.playlists,
-                total_extractor=lambda response: getattr(response, "total", None),
+                total_extractor=lambda response: response.total,
                 count_extractor=lambda response: len(response.playlists),
             ),
         )
@@ -354,9 +354,9 @@ class UserApi(ApiModule):
             pager_strategy=OffsetStrategy[Any, UserFavAlbumResponse](
                 offset_key="offset",
                 page_size_key="size",
-                has_more_extractor=lambda response: bool(getattr(response, "hasmore", 0)),
+                has_more_extractor=lambda response: bool(response.hasmore),
                 items_extractor=lambda response: response.albums,
-                total_extractor=lambda response: getattr(response, "total", None),
+                total_extractor=lambda response: response.total,
                 count_extractor=lambda response: len(response.albums),
             ),
         )

--- a/qqmusic_api/modules/user.py
+++ b/qqmusic_api/modules/user.py
@@ -440,14 +440,14 @@ class UserApi(ApiModule):
                     {
                         **cast("dict[str, Any]", p),
                         "Page": cast("dict[str, Any]", p)["Page"] + 1,
-                        "SongLastid": r.songs[-1].id,
-                        "SingersLastid": r.singers[-1].id,
-                        "StyleLastid": r.styles[-1].id,
+                        "SongLastid": r.songs[-1].id if r.songs else 0,
+                        "SingersLastid": r.singers[-1].id if r.singers else 0,
+                        "StyleLastid": r.styles[-1].id if r.styles else 0,
                     }
                     if (r.singers or r.songs or r.styles)
                     else None
                 ),
-                items_extractor=lambda response: response.songs or response.singers or response.styles,
+                items_extractor=lambda response: response.songs + response.singers + response.styles,
             ),
         )
 

--- a/qqmusic_api/modules/user.py
+++ b/qqmusic_api/modules/user.py
@@ -1,21 +1,15 @@
 """用户相关 API."""
 
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar
 
 from ..core.pagination import MultiFieldContinuationStrategy, OffsetStrategy, PageStrategy
-from ..models.base import Song
 from ..models.request import Credential
 from ..models.songlist import GetSonglistDetailResponse
 from ..models.user import (
-    DislikeItem,
     DislikeListData,
-    FriendEntry,
-    RelationUser,
     UserCreatedSonglistResponse,
-    UserFavAlbumItem,
     UserFavAlbumResponse,
     UserFavMvResponse,
-    UserFavSonglistItem,
     UserFavSonglistResponse,
     UserFriendListResponse,
     UserHomepageResponse,
@@ -103,15 +97,14 @@ class UserApi(ApiModule):
             credential=credential,
             require_login=True,
             response_model=UserRelationListResponse,
-            pager_strategy=OffsetStrategy[Any, UserRelationListResponse, RelationUser](
+            pager_strategy=OffsetStrategy[UserRelationListResponse](
                 offset_key="From",
                 page_size_key="Size",
-                has_more_extractor=lambda response: response.has_more,
-                items_extractor=lambda response: response.users,
-                total_extractor=lambda response: response.total,
-                count_extractor=lambda response: len(response.users),
+                has_more_extractor=lambda r: r.has_more,
+                total_extractor=lambda r: r.total,
+                count_extractor=lambda r: len(r.users),
             ),
-        )
+        ).with_extractor(lambda r: r.users)
 
     def get_fans(
         self,
@@ -136,15 +129,14 @@ class UserApi(ApiModule):
             credential=credential,
             require_login=True,
             response_model=UserRelationListResponse,
-            pager_strategy=OffsetStrategy[Any, UserRelationListResponse, RelationUser](
+            pager_strategy=OffsetStrategy[UserRelationListResponse](
                 offset_key="From",
                 page_size_key="Size",
-                has_more_extractor=lambda response: response.has_more,
-                items_extractor=lambda response: response.users,
-                total_extractor=lambda response: response.total,
-                count_extractor=lambda response: len(response.users),
+                has_more_extractor=lambda r: r.has_more,
+                total_extractor=lambda r: r.total,
+                count_extractor=lambda r: len(r.users),
             ),
-        )
+        ).with_extractor(lambda r: r.users)
 
     def get_friend(
         self,
@@ -167,14 +159,13 @@ class UserApi(ApiModule):
             credential=credential,
             require_login=True,
             response_model=UserFriendListResponse,
-            pager_strategy=PageStrategy[Any, UserFriendListResponse, FriendEntry](
+            pager_strategy=PageStrategy[UserFriendListResponse](
                 page_key="Page",
                 page_size=num,
                 start_page=page - 1,
-                has_more_extractor=lambda response: response.has_more,
-                items_extractor=lambda response: response.friends,
+                has_more_extractor=lambda r: r.has_more,
             ),
-        )
+        ).with_extractor(lambda r: r.friends)
 
     def get_follow_user(
         self,
@@ -199,15 +190,14 @@ class UserApi(ApiModule):
             credential=credential,
             require_login=True,
             response_model=UserRelationListResponse,
-            pager_strategy=OffsetStrategy[Any, UserRelationListResponse, RelationUser](
+            pager_strategy=OffsetStrategy[UserRelationListResponse](
                 offset_key="From",
                 page_size_key="Size",
-                has_more_extractor=lambda response: response.has_more,
-                items_extractor=lambda response: response.users,
-                total_extractor=lambda response: response.total,
-                count_extractor=lambda response: len(response.users),
+                has_more_extractor=lambda r: r.has_more,
+                total_extractor=lambda r: r.total,
+                count_extractor=lambda r: len(r.users),
             ),
-        )
+        ).with_extractor(lambda r: r.users)
 
     def get_created_songlist(self, uin: int, *, credential: Credential | None = None):
         """获取用户创建的歌单列表.
@@ -255,15 +245,14 @@ class UserApi(ApiModule):
             },
             credential=credential,
             response_model=GetSonglistDetailResponse,
-            pager_strategy=OffsetStrategy[Any, GetSonglistDetailResponse, Song](
+            pager_strategy=OffsetStrategy[GetSonglistDetailResponse](
                 offset_key="song_begin",
                 page_size_key="song_num",
-                has_more_extractor=lambda response: bool(response.hasmore),
-                items_extractor=lambda response: response.songs,
-                total_extractor=lambda response: response.total,
+                has_more_extractor=lambda r: bool(r.hasmore),
+                total_extractor=lambda r: r.total,
                 count_extractor=lambda response: len(response.songs),
             ),
-        )
+        ).with_extractor(lambda r: r.songs)
 
     def get_fav_songlist(
         self,
@@ -287,15 +276,14 @@ class UserApi(ApiModule):
             param={"uin": euin, "offset": (page - 1) * num, "size": num},
             credential=credential,
             response_model=UserFavSonglistResponse,
-            pager_strategy=OffsetStrategy[Any, UserFavSonglistResponse, UserFavSonglistItem](
+            pager_strategy=OffsetStrategy[UserFavSonglistResponse](
                 offset_key="offset",
                 page_size_key="size",
-                has_more_extractor=lambda response: bool(response.hasmore),
-                items_extractor=lambda response: response.playlists,
-                total_extractor=lambda response: response.total,
-                count_extractor=lambda response: len(response.playlists),
+                has_more_extractor=lambda r: bool(r.hasmore),
+                total_extractor=lambda r: r.total,
+                count_extractor=lambda r: len(r.playlists),
             ),
-        )
+        ).with_extractor(lambda r: r.playlists)
 
     async def fav_songlist(self, songlist_id: int, *, credential: Credential | None = None) -> bool:
         """收藏歌单 (将他人的公开歌单加入当前账号的收藏).
@@ -357,15 +345,14 @@ class UserApi(ApiModule):
             param={"euin": euin, "offset": (page - 1) * num, "size": num},
             credential=credential,
             response_model=UserFavAlbumResponse,
-            pager_strategy=OffsetStrategy[Any, UserFavAlbumResponse, UserFavAlbumItem](
+            pager_strategy=OffsetStrategy[UserFavAlbumResponse](
                 offset_key="offset",
                 page_size_key="size",
-                has_more_extractor=lambda response: bool(response.hasmore),
-                items_extractor=lambda response: response.albums,
-                total_extractor=lambda response: response.total,
-                count_extractor=lambda response: len(response.albums),
+                has_more_extractor=lambda r: bool(r.hasmore),
+                total_extractor=lambda r: r.total,
+                count_extractor=lambda r: len(r.albums),
             ),
-        )
+        ).with_extractor(lambda r: r.albums)
 
     def get_fav_mv(
         self,
@@ -435,11 +422,11 @@ class UserApi(ApiModule):
             require_login=True,
             response_model=DislikeListData,
             sign=True,
-            pager_strategy=MultiFieldContinuationStrategy[Any, DislikeListData, DislikeItem](
+            pager_strategy=MultiFieldContinuationStrategy[DislikeListData](
                 build_next_params=lambda p, r: (
                     {
-                        **cast("dict[str, Any]", p),
-                        "Page": cast("dict[str, Any]", p)["Page"] + 1,
+                        **p,
+                        "Page": p["Page"] + 1,
                         "SongLastid": r.songs[-1].id if r.songs else 0,
                         "SingersLastid": r.singers[-1].id if r.singers else 0,
                         "StyleLastid": r.styles[-1].id if r.styles else 0,
@@ -447,7 +434,6 @@ class UserApi(ApiModule):
                     if (r.singers or r.songs or r.styles)
                     else None
                 ),
-                items_extractor=lambda response: response.songs + response.singers + response.styles,
             ),
         )
 

--- a/qqmusic_api/modules/user.py
+++ b/qqmusic_api/modules/user.py
@@ -2,7 +2,7 @@
 
 from typing import Any, ClassVar, cast
 
-from ..core.pagination import MultiFieldContinuationStrategy, OffsetStrategy, PagerMeta, PageStrategy, ResponseAdapter
+from ..core.pagination import MultiFieldContinuationStrategy, OffsetStrategy, PageStrategy
 from ..models.request import Credential
 from ..models.songlist import GetSonglistDetailResponse
 from ..models.user import (
@@ -97,13 +97,12 @@ class UserApi(ApiModule):
             credential=credential,
             require_login=True,
             response_model=UserRelationListResponse,
-            pager_meta=PagerMeta(
-                strategy=OffsetStrategy(offset_key="From", page_size_key="Size"),
-                adapter=ResponseAdapter(
-                    has_more_flag="has_more",
-                    total="total",
-                    count=lambda response: len(response.users),
-                ),
+            pager_strategy=OffsetStrategy[Any, UserRelationListResponse](
+                offset_key="From",
+                page_size_key="Size",
+                has_more_extractor=lambda response: bool(response.has_more),
+                total_extractor=lambda response: getattr(response, "total", None),
+                count_extractor=lambda response: len(response.users),
             ),
         )
 
@@ -130,13 +129,12 @@ class UserApi(ApiModule):
             credential=credential,
             require_login=True,
             response_model=UserRelationListResponse,
-            pager_meta=PagerMeta(
-                strategy=OffsetStrategy(offset_key="From", page_size_key="Size"),
-                adapter=ResponseAdapter(
-                    has_more_flag="has_more",
-                    total="total",
-                    count=lambda response: len(response.users),
-                ),
+            pager_strategy=OffsetStrategy[Any, UserRelationListResponse](
+                offset_key="From",
+                page_size_key="Size",
+                has_more_extractor=lambda response: bool(response.has_more),
+                total_extractor=lambda response: getattr(response, "total", None),
+                count_extractor=lambda response: len(response.users),
             ),
         )
 
@@ -161,9 +159,11 @@ class UserApi(ApiModule):
             credential=credential,
             require_login=True,
             response_model=UserFriendListResponse,
-            pager_meta=PagerMeta(
-                strategy=PageStrategy(page_key="Page", page_size=num, start_page=page - 1),
-                adapter=ResponseAdapter(has_more_flag="has_more"),
+            pager_strategy=PageStrategy[Any, UserFriendListResponse](
+                page_key="Page",
+                page_size=num,
+                start_page=page - 1,
+                has_more_extractor=lambda response: bool(response.has_more),
             ),
         )
 
@@ -190,13 +190,12 @@ class UserApi(ApiModule):
             credential=credential,
             require_login=True,
             response_model=UserRelationListResponse,
-            pager_meta=PagerMeta(
-                strategy=OffsetStrategy(offset_key="From", page_size_key="Size"),
-                adapter=ResponseAdapter(
-                    has_more_flag="has_more",
-                    total="total",
-                    count=lambda response: len(response.users),
-                ),
+            pager_strategy=OffsetStrategy[Any, UserRelationListResponse](
+                offset_key="From",
+                page_size_key="Size",
+                has_more_extractor=lambda response: bool(response.has_more),
+                total_extractor=lambda response: getattr(response, "total", None),
+                count_extractor=lambda response: len(response.users),
             ),
         )
 
@@ -246,13 +245,12 @@ class UserApi(ApiModule):
             },
             credential=credential,
             response_model=GetSonglistDetailResponse,
-            pager_meta=PagerMeta(
-                strategy=OffsetStrategy(offset_key="song_begin", page_size_key="song_num"),
-                adapter=ResponseAdapter(
-                    has_more_flag="hasmore",
-                    total="total",
-                    count=lambda response: len(response.songs),
-                ),
+            pager_strategy=OffsetStrategy[Any, GetSonglistDetailResponse](
+                offset_key="song_begin",
+                page_size_key="song_num",
+                has_more_extractor=lambda response: bool(getattr(response, "hasmore", 0)),
+                total_extractor=lambda response: getattr(response, "total", None),
+                count_extractor=lambda response: len(response.songs),
             ),
         )
 
@@ -278,13 +276,12 @@ class UserApi(ApiModule):
             param={"uin": euin, "offset": (page - 1) * num, "size": num},
             credential=credential,
             response_model=UserFavSonglistResponse,
-            pager_meta=PagerMeta(
-                strategy=OffsetStrategy(offset_key="offset", page_size_key="size"),
-                adapter=ResponseAdapter(
-                    has_more_flag="hasmore",
-                    total="total",
-                    count=lambda response: len(response.playlists),
-                ),
+            pager_strategy=OffsetStrategy[Any, UserFavSonglistResponse](
+                offset_key="offset",
+                page_size_key="size",
+                has_more_extractor=lambda response: bool(getattr(response, "hasmore", 0)),
+                total_extractor=lambda response: getattr(response, "total", None),
+                count_extractor=lambda response: len(response.playlists),
             ),
         )
 
@@ -348,13 +345,12 @@ class UserApi(ApiModule):
             param={"euin": euin, "offset": (page - 1) * num, "size": num},
             credential=credential,
             response_model=UserFavAlbumResponse,
-            pager_meta=PagerMeta(
-                strategy=OffsetStrategy(offset_key="offset", page_size_key="size"),
-                adapter=ResponseAdapter(
-                    has_more_flag="hasmore",
-                    total="total",
-                    count=lambda response: len(response.albums),
-                ),
+            pager_strategy=OffsetStrategy[Any, UserFavAlbumResponse](
+                offset_key="offset",
+                page_size_key="size",
+                has_more_extractor=lambda response: bool(getattr(response, "hasmore", 0)),
+                total_extractor=lambda response: getattr(response, "total", None),
+                count_extractor=lambda response: len(response.albums),
             ),
         )
 
@@ -426,21 +422,18 @@ class UserApi(ApiModule):
             require_login=True,
             response_model=DislikeListData,
             sign=True,
-            pager_meta=PagerMeta(
-                strategy=MultiFieldContinuationStrategy(
-                    build_next_params=lambda p, r, a: (
-                        {
-                            **cast("dict[str, Any]", p),
-                            "Page": cast("dict[str, Any]", p)["Page"] + 1,
-                            "SongLastid": r.songs[-1].id,
-                            "SingersLastid": r.singers[-1].id,
-                            "StyleLastid": r.styles[-1].id,
-                        }
-                        if (r.singers or r.songs or r.styles)
-                        else None
-                    ),
+            pager_strategy=MultiFieldContinuationStrategy[Any, DislikeListData](
+                build_next_params=lambda p, r: (
+                    {
+                        **cast("dict[str, Any]", p),
+                        "Page": cast("dict[str, Any]", p)["Page"] + 1,
+                        "SongLastid": r.songs[-1].id,
+                        "SingersLastid": r.singers[-1].id,
+                        "StyleLastid": r.styles[-1].id,
+                    }
+                    if (r.singers or r.songs or r.styles)
+                    else None
                 ),
-                adapter=ResponseAdapter(),
             ),
         )
 

--- a/qqmusic_api/utils/mqtt.py
+++ b/qqmusic_api/utils/mqtt.py
@@ -3,6 +3,7 @@
 import logging
 import ssl
 import threading
+import types
 from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass, field
 from enum import IntEnum
@@ -17,6 +18,7 @@ import paho.mqtt.client as mqtt
 from paho.mqtt.enums import CallbackAPIVersion
 from paho.mqtt.packettypes import PacketTypes
 from paho.mqtt.properties import Properties
+from typing_extensions import Self
 
 if TYPE_CHECKING:
     from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
@@ -133,7 +135,7 @@ class Client:
 
         self._mqtt_client: mqtt.Client | None = None
 
-    async def __aenter__(self) -> "Client":
+    async def __aenter__(self) -> Self:
         """进入异步上下文."""
         self._event_loop_token = anyio.lowlevel.current_token()
         return self
@@ -142,7 +144,7 @@ class Client:
         self,
         exc_type: type[BaseException] | None,
         exc_val: BaseException | None,
-        exc_tb: Any | None,
+        exc_tb: types.TracebackType | None,
     ) -> None:
         """退出异步上下文并关闭连接."""
         await self.disconnect()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,8 +104,6 @@ def handle_unavailable_api_errors(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(Client, "execute", execute_with_rate_limit_retry)
     monkeypatch.setattr(Client, "gather", gather_with_rate_limit_retry)
 
-    return
-
 
 @pytest_asyncio.fixture
 async def client(pytestconfig: pytest.Config) -> AsyncIterator[Client]:

--- a/tests/test_album.py
+++ b/tests/test_album.py
@@ -40,10 +40,10 @@ async def test_get_new_album(client: Client, area: int) -> None:
 
 async def test_get_new_album_pagination(client: Client) -> None:
     """测试新碟上架分页返回不同数据."""
-    pager = client.album.get_new_album(area=1, num=5, page=1).paginate(limit=2)
-    first = await pager.next()
-    second = await pager.next()
-    assert first.albums[0].mid != second.albums[0].mid
+    req = client.album.get_new_album(area=1, num=5, page=1)
+    pages = [page async for page in req.paginate(limit=2)]
+    assert len(pages) == 2
+    assert pages[0].albums[0].mid != pages[1].albums[0].mid
 
 
 async def test_fav_album_roundtrip(authenticated_client: Client) -> None:

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -60,24 +60,18 @@ async def test_get_moment_comments(client: Client) -> None:
 
 async def test_get_hot_comments_paginate(client: Client) -> None:
     """测试热评列表支持手动逐页拉取."""
-    pager = client.comment.get_hot_comments(102065756, page_num=1, page_size=5).paginate(limit=2)
+    req = client.comment.get_hot_comments(102065756, page_num=1, page_size=5)
+    pages = [page async for page in req.paginate(limit=2)]
 
-    assert pager.has_more() is True
-    first_page = await pager.next()
-    assert pager.has_more() is True
-    second_page = await pager.next()
-
-    assert first_page.comments
-    assert second_page.comments
-    assert pager.has_more() is False
-    with pytest.raises(StopAsyncIteration):
-        await pager.next()
+    assert len(pages) == 2
+    assert pages[0].comments
+    assert pages[1].comments
 
 
 async def test_get_moment_comments_paginate(client: Client) -> None:
     """测试时刻评论游标分页能力."""
-    pager = client.comment.get_moment_comments(102065756, page_size=5).paginate(limit=2)
-    pages = [page async for page in pager]
+    req = client.comment.get_moment_comments(102065756, page_size=5)
+    pages = [page async for page in req.paginate(limit=2)]
 
     assert len(pages) == 2
     assert pages[0].comments

--- a/tests/test_mv.py
+++ b/tests/test_mv.py
@@ -38,7 +38,7 @@ async def test_get_mv_list(client: Client) -> None:
 
 async def test_get_mv_list_pagination(client: Client) -> None:
     """测试 MV 分类列表分页返回不同数据."""
-    pager = client.mv.get_mv_list(num=5, page=1).paginate(limit=2)
-    first = await pager.next()
-    second = await pager.next()
-    assert first.items[0].vid != second.items[0].vid
+    req = client.mv.get_mv_list(num=5, page=1)
+    pages = [page async for page in req.paginate(limit=2)]
+    assert len(pages) == 2
+    assert pages[0].items[0].vid != pages[1].items[0].vid

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -211,7 +211,7 @@ async def test_async_pager_and_collect_items():
     resp2 = DummyResponse(total=30, items=[11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
     resp3 = DummyResponse(total=30, items=[21, 22, 23, 24, 25, 26, 27, 28, 29, 30])
 
-    strategy_with_items = OffsetStrategy[Any, DummyResponse](
+    strategy_with_items = OffsetStrategy[Any, DummyResponse, int](
         offset_key="start",
         page_size=10,
         total_extractor=lambda r: r.total,
@@ -286,7 +286,7 @@ async def test_async_refresher_and_stream():
     resp2 = DummyResponse(has_more=True, next_cursor="cur2", items=["c", "d"])
     resp3 = DummyResponse(has_more=False, next_cursor=None, items=["e", "f"])
 
-    strategy = BatchRefreshStrategy[Any, DummyResponse](
+    strategy = BatchRefreshStrategy[Any, DummyResponse, str](
         refresh_key="vec",
         cursor_extractor=lambda r: r.next_cursor,
         has_more_extractor=lambda r: r.has_more,

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,188 @@
+"""分页与换一批策略单元测试."""
+
+from typing import Any, cast
+
+import pytest
+from pydantic import BaseModel
+
+from qqmusic_api.core.pagination import (
+    BatchRefreshStrategy,
+    CursorStrategy,
+    MultiFieldContinuationStrategy,
+    OffsetStrategy,
+    PageStrategy,
+)
+from qqmusic_api.core.request import PaginatedRequest, RefreshableRequest
+
+
+class DummyResponse(BaseModel):
+    """测试用简单响应结构."""
+
+    has_more: bool | None = None
+    total: int | None = None
+    items: list[Any] | None = None
+    next_cursor: str | None = None
+
+
+def test_page_strategy_has_next_and_next_params():
+    """测试基于页码的分页策略 has_next 与 next_params."""
+    strategy = PageStrategy[Any, DummyResponse](
+        page_key="page",
+        page_size=10,
+        start_page=1,
+        total_extractor=lambda r: r.total,
+        has_more_extractor=lambda r: r.has_more,
+    )
+    # 当 has_more 显式提供时
+    resp_flag = DummyResponse(has_more=True)
+    assert strategy.has_next({"page": 1}, resp_flag) is True
+
+    resp_no_flag = DummyResponse(has_more=False)
+    assert strategy.has_next({"page": 1}, resp_no_flag) is False
+
+    # 根据 total 判断
+    resp_total = DummyResponse(has_more=None, total=25)
+    assert strategy.has_next({"page": 1}, resp_total) is True
+    assert strategy.has_next({"page": 3}, resp_total) is False
+
+    # next_params 增量
+    next_p = strategy.next_params({"page": 1}, resp_total)
+    assert next_p["page"] == 2
+
+
+def test_offset_strategy_has_next_and_next_params():
+    """测试基于偏移量的分页策略 has_next 与 next_params."""
+    strategy = OffsetStrategy[Any, DummyResponse](
+        offset_key="start",
+        page_size_key="size",
+        start_offset=0,
+        total_extractor=lambda r: r.total,
+        count_extractor=lambda r: len(r.items) if r.items is not None else None,
+    )
+
+    resp = DummyResponse(total=30, items=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    params = {"start": 0, "size": 10}
+
+    assert strategy.has_next(params, resp) is True
+
+    next_p = strategy.next_params(params, resp)
+    assert next_p["start"] == 10
+
+    # 到底部
+    last_params = {"start": 20, "size": 10}
+    last_resp = DummyResponse(total=30, items=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    assert strategy.has_next(last_params, last_resp) is False
+
+
+def test_batch_refresh_strategy():
+    """测试换一批策略 has_next 与 next_params."""
+    strategy = BatchRefreshStrategy[Any, DummyResponse](
+        refresh_key="vec",
+        cursor_extractor=lambda r: r.next_cursor,
+        has_more_extractor=lambda r: r.has_more,
+    )
+
+    resp_more = DummyResponse(has_more=True, next_cursor="cur2")
+    params = {"vec": "cur1"}
+
+    assert strategy.has_next(params, resp_more) is True
+    assert strategy.next_params(params, resp_more) == {"vec": "cur2"}
+
+    # 当 has_more 为 None 但游标不同
+    resp_none = DummyResponse(has_more=None, next_cursor="cur2")
+    assert strategy.has_next(params, resp_none) is True
+
+    # 游标相同
+    same_params = {"vec": "cur2"}
+    assert strategy.has_next(same_params, resp_more) is False
+
+
+def test_cursor_strategy():
+    """测试游标策略 has_next 与 next_params."""
+    strategy = CursorStrategy[Any, DummyResponse](
+        cursor_key="pos",
+        cursor_extractor=lambda r: r.next_cursor,
+        has_more_extractor=lambda r: r.has_more,
+    )
+
+    resp = DummyResponse(has_more=True, next_cursor="100")
+    params = {"pos": "0"}
+
+    assert strategy.has_next(params, resp) is True
+    assert strategy.next_params(params, resp) == {"pos": "100"}
+
+
+def test_multi_field_continuation_strategy():
+    """测试多字段延续策略 has_next 与 next_params."""
+
+    def builder(p: dict[str, Any], r: DummyResponse) -> dict[str, Any] | None:
+        if not r.items:
+            return None
+        return {**p, "page": p.get("page", 1) + 1}
+
+    strategy = MultiFieldContinuationStrategy[Any, DummyResponse](builder)
+
+    resp_has = DummyResponse(items=[1, 2])
+    resp_empty = DummyResponse(items=[])
+
+    params = {"page": 1}
+    assert strategy.has_next(params, resp_has) is True
+    assert strategy.next_params(params, resp_has) == {"page": 2}
+
+    assert strategy.has_next(params, resp_empty) is False
+    with pytest.raises(ValueError, match="分页响应未提供继续翻页所需的 continuation 数据"):
+        strategy.next_params(params, resp_empty)
+
+
+@pytest.mark.asyncio
+async def test_paginated_request_paginate():
+    """测试 PaginatedRequest 的 async for 迭代流程."""
+
+    class DummyPaginatedRequest(PaginatedRequest):
+        def __await__(self):
+            async def _coro():
+                return DummyResponse(total=20, items=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+
+            return _coro().__await__()
+
+    strategy = OffsetStrategy[Any, DummyResponse](
+        offset_key="start",
+        page_size_key="size",
+        total_extractor=lambda r: r.total,
+    )
+
+    req = DummyPaginatedRequest(
+        _client=cast("Any", None),
+        module="test",
+        method="test",
+        param={"start": 0, "size": 10},
+        pager_strategy=strategy,
+    )
+
+    results = [res async for res in req.paginate(limit=2)]
+    assert len(results) == 2
+
+
+def test_refreshable_request_next_request():
+    """测试 RefreshableRequest 的 next_request 方法."""
+    strategy = BatchRefreshStrategy[Any, DummyResponse](
+        refresh_key="vec",
+        cursor_extractor=lambda r: r.next_cursor,
+        has_more_extractor=lambda r: r.has_more,
+    )
+
+    req = RefreshableRequest(
+        _client=cast("Any", None),
+        module="test",
+        method="test",
+        param={"vec": "cur1"},
+        refresh_strategy=strategy,
+    )
+
+    resp_more = DummyResponse(has_more=True, next_cursor="cur2")
+    next_req = req.next_request(resp_more)
+    assert next_req is not None
+    assert cast("dict[str, Any]", next_req.param)["vec"] == "cur2"
+
+    resp_end = DummyResponse(has_more=False)
+    assert req.next_request(resp_end) is None

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -13,7 +13,12 @@ from qqmusic_api.core.pagination import (
     OffsetStrategy,
     PageStrategy,
 )
-from qqmusic_api.core.request import PaginatedRequest, RefreshableRequest
+from qqmusic_api.core.request import (
+    ItemPaginatedRequest,
+    ItemRefreshableRequest,
+    PaginatedRequest,
+    RefreshableRequest,
+)
 
 
 class DummyResponse(BaseModel):
@@ -143,7 +148,7 @@ def test_multi_field_continuation_strategy():
 async def test_paginated_request_paginate():
     """测试 PaginatedRequest 的 async for 迭代流程."""
 
-    class DummyPaginatedRequest(PaginatedRequest[DummyResponse, int]):
+    class DummyPaginatedRequest(PaginatedRequest[DummyResponse]):
         def __await__(self):
             async def _coro():
                 return DummyResponse(total=20, items=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
@@ -198,7 +203,7 @@ async def test_async_pager_and_collect_items():
     """测试 AsyncPager 控制器以及 PaginatedRequest 的 collect 与 iter_items 功能."""
 
     @dataclass
-    class MockPaginatedRequest(PaginatedRequest[DummyResponse, int]):
+    class MockPaginatedRequest(ItemPaginatedRequest[DummyResponse, int]):
         responses: list[DummyResponse] = field(default_factory=list)
 
         def __await__(self):
@@ -276,7 +281,7 @@ async def test_async_refresher_and_stream():
     """测试 AsyncRefresher 控制器以及 RefreshableRequest 的 refresh_stream 与 aiter 功能."""
 
     @dataclass
-    class MockRefreshableRequest(RefreshableRequest[DummyResponse, str]):
+    class MockRefreshableRequest(ItemRefreshableRequest[DummyResponse, str]):
         response_map: dict[str, DummyResponse] = field(default_factory=dict)
 
         def __await__(self):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -384,3 +384,18 @@ async def test_page_strategy_count_fallback():
 
     assert strategy.has_next({"page": 1}, resp1) is True
     assert strategy.has_next({"page": 2}, resp2) is False
+
+
+@pytest.mark.asyncio
+async def test_cursor_strategy_short_circuit_has_more():
+    """测试 CursorStrategy 在 has_more 为 True 时短路判定未终止, 不被少量条目误判."""
+    strategy = CursorStrategy[DummyResponse](
+        cursor_key="cursor",
+        cursor_extractor=lambda r: r.next_cursor,
+        has_more_extractor=lambda r: r.has_more,
+        count_extractor=lambda r: len(r.items or []),
+        page_size=10,
+    )
+
+    resp = DummyResponse(has_more=True, items=[1, 2], next_cursor="next_c")
+    assert strategy.has_next({"cursor": "init_c"}, resp) is True

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -32,7 +32,7 @@ class DummyResponse(BaseModel):
 
 def test_page_strategy_has_next_and_next_params():
     """测试基于页码的分页策略 has_next 与 next_params."""
-    strategy = PageStrategy[Any, DummyResponse](
+    strategy = PageStrategy[DummyResponse](
         page_key="page",
         page_size=10,
         start_page=1,
@@ -58,7 +58,7 @@ def test_page_strategy_has_next_and_next_params():
 
 def test_offset_strategy_has_next_and_next_params():
     """测试基于偏移量的分页策略 has_next 与 next_params."""
-    strategy = OffsetStrategy[Any, DummyResponse](
+    strategy = OffsetStrategy[DummyResponse](
         offset_key="start",
         page_size_key="size",
         start_offset=0,
@@ -86,7 +86,7 @@ def test_offset_strategy_has_next_and_next_params():
 
 def test_batch_refresh_strategy():
     """测试换一批策略 has_next 与 next_params."""
-    strategy = BatchRefreshStrategy[Any, DummyResponse](
+    strategy = BatchRefreshStrategy[DummyResponse](
         refresh_key="vec",
         cursor_extractor=lambda r: r.next_cursor,
         has_more_extractor=lambda r: r.has_more,
@@ -109,7 +109,7 @@ def test_batch_refresh_strategy():
 
 def test_cursor_strategy():
     """测试游标策略 has_next 与 next_params."""
-    strategy = CursorStrategy[Any, DummyResponse](
+    strategy = CursorStrategy[DummyResponse](
         cursor_key="pos",
         cursor_extractor=lambda r: r.next_cursor,
         has_more_extractor=lambda r: r.has_more,
@@ -130,7 +130,7 @@ def test_multi_field_continuation_strategy():
             return None
         return {**p, "page": p.get("page", 1) + 1}
 
-    strategy = MultiFieldContinuationStrategy[Any, DummyResponse](builder)
+    strategy = MultiFieldContinuationStrategy[DummyResponse](builder)
 
     resp_has = DummyResponse(items=[1, 2])
     resp_empty = DummyResponse(items=[])
@@ -155,7 +155,7 @@ async def test_paginated_request_paginate():
 
             return _coro().__await__()
 
-    strategy = OffsetStrategy[Any, DummyResponse](
+    strategy = OffsetStrategy[DummyResponse](
         offset_key="start",
         page_size_key="size",
         total_extractor=lambda r: r.total,
@@ -175,7 +175,7 @@ async def test_paginated_request_paginate():
 
 def test_refreshable_request_next_request():
     """测试 RefreshableRequest 的 next_request 方法."""
-    strategy = BatchRefreshStrategy[Any, DummyResponse](
+    strategy = BatchRefreshStrategy[DummyResponse](
         refresh_key="vec",
         cursor_extractor=lambda r: r.next_cursor,
         has_more_extractor=lambda r: r.has_more,
@@ -220,11 +220,10 @@ async def test_async_pager_and_collect_items():
     resp2 = DummyResponse(total=30, items=[11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
     resp3 = DummyResponse(total=30, items=[21, 22, 23, 24, 25, 26, 27, 28, 29, 30])
 
-    strategy_with_items = OffsetStrategy[Any, DummyResponse, int](
+    strategy = OffsetStrategy[DummyResponse](
         offset_key="start",
         page_size=10,
         total_extractor=lambda r: r.total,
-        items_extractor=lambda r: r.items,
     )
 
     req = MockPaginatedRequest(
@@ -232,7 +231,8 @@ async def test_async_pager_and_collect_items():
         module="test",
         method="test",
         param={"start": 0},
-        pager_strategy=strategy_with_items,
+        pager_strategy=strategy,
+        items_extractor=lambda r: r.items,
         responses=[resp1, resp2, resp3],
     )
 
@@ -258,22 +258,18 @@ async def test_async_pager_and_collect_items():
     all_items = await req.collect_items()
     assert all_items == list(range(1, 31))
 
-    # 测试未配置 items_extractor 触发 TypeError
-    strategy_no_items = OffsetStrategy[Any, DummyResponse](
-        offset_key="start",
-        page_size=10,
-        total_extractor=lambda r: r.total,
-    )
-    req_no_items = MockPaginatedRequest(
+    # 测试 items_extractor 返回 None 的处理
+    req_none_items = MockPaginatedRequest(
         _client=cast("Any", None),
         module="test",
         method="test",
         param={"start": 0},
-        pager_strategy=strategy_no_items,
+        pager_strategy=strategy,
+        items_extractor=lambda r: None,
         responses=[resp1],
     )
-    with pytest.raises(TypeError, match="未配置 items_extractor"):
-        await req_no_items.collect_items()
+    items_none = await req_none_items.collect_items()
+    assert items_none == []
 
 
 @pytest.mark.asyncio
@@ -295,11 +291,10 @@ async def test_async_refresher_and_stream():
     resp2 = DummyResponse(has_more=True, next_cursor="cur2", items=["c", "d"])
     resp3 = DummyResponse(has_more=False, next_cursor=None, items=["e", "f"])
 
-    strategy = BatchRefreshStrategy[Any, DummyResponse, str](
+    strategy = BatchRefreshStrategy[DummyResponse](
         refresh_key="vec",
         cursor_extractor=lambda r: r.next_cursor,
         has_more_extractor=lambda r: r.has_more,
-        items_extractor=lambda r: r.items,
     )
 
     req = MockRefreshableRequest(
@@ -308,6 +303,7 @@ async def test_async_refresher_and_stream():
         method="test",
         param={"vec": "cur0"},
         refresh_strategy=strategy,
+        items_extractor=lambda r: r.items,
         response_map={"cur0": resp1, "cur1": resp2, "cur2": resp3},
     )
 
@@ -324,6 +320,12 @@ async def test_async_refresher_and_stream():
     with pytest.raises(StopAsyncIteration):
         await refresher.next()
 
+    # 测试 limit=0 时 first() 短路抛出 StopAsyncIteration
+    refresher_zero = req.refresher(limit=0)
+    assert refresher_zero.has_more() is False
+    with pytest.raises(StopAsyncIteration):
+        await refresher_zero.first()
+
     # 测试 async for batch in req (aiter)
     batches = [batch async for batch in req]
     assert len(batches) == 3
@@ -337,7 +339,7 @@ async def test_async_refresher_and_stream():
 @pytest.mark.asyncio
 async def test_with_extractor_combinator():
     """测试通过 with_extractor 动态注入数据项提取器."""
-    strategy = PageStrategy[Any, DummyResponse](
+    strategy = PageStrategy[DummyResponse](
         page_key="page",
         page_size=10,
         start_page=1,

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -74,6 +74,10 @@ def test_offset_strategy_has_next_and_next_params():
     last_resp = DummyResponse(total=30, items=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
     assert strategy.has_next(last_params, last_resp) is False
 
+    # 当未提供 total/has_more 时, 安全返回 False 而非抛错
+    empty_resp = DummyResponse(total=None)
+    assert strategy.has_next(params, empty_resp) is False
+
 
 def test_batch_refresh_strategy():
     """测试换一批策略 has_next 与 next_params."""
@@ -194,7 +198,7 @@ async def test_async_pager_and_collect_items():
     """测试 AsyncPager 控制器以及 PaginatedRequest 的 collect 与 iter_items 功能."""
 
     @dataclass
-    class MockPaginatedRequest(PaginatedRequest):
+    class MockPaginatedRequest(PaginatedRequest[DummyResponse, int]):
         responses: list[DummyResponse] = field(default_factory=list)
 
         def __await__(self):
@@ -272,7 +276,7 @@ async def test_async_refresher_and_stream():
     """测试 AsyncRefresher 控制器以及 RefreshableRequest 的 refresh_stream 与 aiter 功能."""
 
     @dataclass
-    class MockRefreshableRequest(RefreshableRequest):
+    class MockRefreshableRequest(RefreshableRequest[DummyResponse, str]):
         response_map: dict[str, DummyResponse] = field(default_factory=dict)
 
         def __await__(self):

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -15,9 +15,7 @@ from qqmusic_api.core.pagination import (
 )
 from qqmusic_api.core.request import (
     ItemPaginatedRequest,
-    ItemRefreshableRequest,
     PaginatedRequest,
-    RefreshableRequest,
 )
 
 
@@ -173,20 +171,20 @@ async def test_paginated_request_paginate():
     assert len(results) == 2
 
 
-def test_refreshable_request_next_request():
-    """测试 RefreshableRequest 的 next_request 方法."""
+def test_batch_refresh_request_next_request():
+    """测试 PaginatedRequest 配合 BatchRefreshStrategy 的 next_request 方法."""
     strategy = BatchRefreshStrategy[DummyResponse](
         refresh_key="vec",
         cursor_extractor=lambda r: r.next_cursor,
         has_more_extractor=lambda r: r.has_more,
     )
 
-    req = RefreshableRequest(
+    req = PaginatedRequest(
         _client=cast("Any", None),
         module="test",
         method="test",
         param={"vec": "cur1"},
-        refresh_strategy=strategy,
+        pager_strategy=strategy,
     )
 
     resp_more = DummyResponse(has_more=True, next_cursor="cur2")
@@ -273,11 +271,11 @@ async def test_async_pager_and_collect_items():
 
 
 @pytest.mark.asyncio
-async def test_async_refresher_and_stream():
-    """测试 AsyncRefresher 控制器以及 RefreshableRequest 的 refresh_stream 与 aiter 功能."""
+async def test_async_pager_with_batch_refresh_strategy():
+    """测试 AsyncPager 控制器 (含 first/next) 以及配合 BatchRefreshStrategy 的工作功能."""
 
     @dataclass
-    class MockRefreshableRequest(ItemRefreshableRequest[DummyResponse, str]):
+    class MockPaginatedRequest(ItemPaginatedRequest[DummyResponse, str]):
         response_map: dict[str, DummyResponse] = field(default_factory=dict)
 
         def __await__(self):
@@ -297,34 +295,34 @@ async def test_async_refresher_and_stream():
         has_more_extractor=lambda r: r.has_more,
     )
 
-    req = MockRefreshableRequest(
+    req = MockPaginatedRequest(
         _client=cast("Any", None),
         module="test",
         method="test",
         param={"vec": "cur0"},
-        refresh_strategy=strategy,
+        pager_strategy=strategy,
         items_extractor=lambda r: r.items,
         response_map={"cur0": resp1, "cur1": resp2, "cur2": resp3},
     )
 
-    # 测试 refresher 的 first 与 next
-    refresher = req.refresher(limit=2)
-    assert refresher.has_more() is True
-    b1_first = await refresher.first()
+    # 测试 pager 的 first 与 next
+    pager = req.pager(limit=2)
+    assert pager.has_more() is True
+    b1_first = await pager.first()
     assert b1_first.items == ["a", "b"]
-    b2 = await refresher.next()
+    b2 = await pager.next()
     assert b2.items == ["c", "d"]
-    b1_again = await refresher.first()
+    b1_again = await pager.first()
     assert b1_again.items == ["a", "b"]
-    assert refresher.has_more() is False
+    assert pager.has_more() is False
     with pytest.raises(StopAsyncIteration):
-        await refresher.next()
+        await pager.next()
 
     # 测试 limit=0 时 first() 短路抛出 StopAsyncIteration
-    refresher_zero = req.refresher(limit=0)
-    assert refresher_zero.has_more() is False
+    pager_zero = req.pager(limit=0)
+    assert pager_zero.has_more() is False
     with pytest.raises(StopAsyncIteration):
-        await refresher_zero.first()
+        await pager_zero.first()
 
     # 测试 async for batch in req (aiter)
     batches = [batch async for batch in req]

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -367,3 +367,20 @@ async def test_with_extractor_combinator():
 
     items = await item_req.collect_items()
     assert items == [1, 2, 3, 4, 5, 6]
+
+
+@pytest.mark.asyncio
+async def test_page_strategy_count_fallback():
+    """测试 PageStrategy 仅配置 count_extractor 和 page_size 时依据数据条目数终止翻页."""
+    strategy = PageStrategy[DummyResponse](
+        page_key="page",
+        page_size=10,
+        start_page=1,
+        count_extractor=lambda r: len(r.items or []),
+    )
+
+    resp1 = DummyResponse(items=list(range(10)))
+    resp2 = DummyResponse(items=[1, 2, 3])
+
+    assert strategy.has_next({"page": 1}, resp1) is True
+    assert strategy.has_next({"page": 2}, resp2) is False

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -143,7 +143,7 @@ def test_multi_field_continuation_strategy():
 async def test_paginated_request_paginate():
     """测试 PaginatedRequest 的 async for 迭代流程."""
 
-    class DummyPaginatedRequest(PaginatedRequest):
+    class DummyPaginatedRequest(PaginatedRequest[DummyResponse, int]):
         def __await__(self):
             async def _coro():
                 return DummyResponse(total=20, items=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -332,3 +332,38 @@ async def test_async_refresher_and_stream():
     # 测试 collect_items
     items_3 = await req.collect_items(limit=3)
     assert items_3 == ["a", "b", "c"]
+
+
+@pytest.mark.asyncio
+async def test_with_extractor_combinator():
+    """测试通过 with_extractor 动态注入数据项提取器."""
+    strategy = PageStrategy[Any, DummyResponse](
+        page_key="page",
+        page_size=10,
+        start_page=1,
+        total_extractor=lambda r: r.total,
+        has_more_extractor=lambda r: r.has_more,
+    )
+
+    resp1 = DummyResponse(total=30, has_more=True, items=[1, 2, 3])
+    resp2 = DummyResponse(total=30, has_more=False, items=[4, 5, 6])
+
+    class MockClient:
+        async def execute(self, req: Any) -> DummyResponse:
+            page = req.param["page"]
+            return resp1 if page == 1 else resp2
+
+    req = PaginatedRequest(
+        _client=cast("Any", MockClient()),
+        module="test",
+        method="test",
+        param={"page": 1},
+        response_model=cast("Any", None),
+        pager_strategy=strategy,
+    )
+
+    item_req = req.with_extractor(lambda r: r.items or [])
+    assert isinstance(item_req, ItemPaginatedRequest)
+
+    items = await item_req.collect_items()
+    assert items == [1, 2, 3, 4, 5, 6]

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,5 +1,6 @@
 """分页与换一批策略单元测试."""
 
+from dataclasses import dataclass, field
 from typing import Any, cast
 
 import pytest
@@ -186,3 +187,139 @@ def test_refreshable_request_next_request():
 
     resp_end = DummyResponse(has_more=False)
     assert req.next_request(resp_end) is None
+
+
+@pytest.mark.asyncio
+async def test_async_pager_and_collect_items():
+    """测试 AsyncPager 控制器以及 PaginatedRequest 的 collect 与 iter_items 功能."""
+
+    @dataclass
+    class MockPaginatedRequest(PaginatedRequest):
+        responses: list[DummyResponse] = field(default_factory=list)
+
+        def __await__(self):
+            async def _coro():
+                start = cast("dict[str, Any]", self.param).get("start", 0)
+                idx = start // 10
+                if idx < len(self.responses):
+                    return self.responses[idx]
+                return DummyResponse(total=len(self.responses) * 10, items=[])
+
+            return _coro().__await__()
+
+    resp1 = DummyResponse(total=30, items=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    resp2 = DummyResponse(total=30, items=[11, 12, 13, 14, 15, 16, 17, 18, 19, 20])
+    resp3 = DummyResponse(total=30, items=[21, 22, 23, 24, 25, 26, 27, 28, 29, 30])
+
+    strategy_with_items = OffsetStrategy[Any, DummyResponse](
+        offset_key="start",
+        page_size=10,
+        total_extractor=lambda r: r.total,
+        items_extractor=lambda r: r.items,
+    )
+
+    req = MockPaginatedRequest(
+        _client=cast("Any", None),
+        module="test",
+        method="test",
+        param={"start": 0},
+        pager_strategy=strategy_with_items,
+        responses=[resp1, resp2, resp3],
+    )
+
+    # 测试 pager 手动 step 推进与 limit
+    pager = req.pager(limit=2)
+    assert pager.has_more() is True
+    page1 = await pager.next()
+    assert page1.items == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    page2 = await pager.next()
+    assert page2.items == [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    assert pager.has_more() is False
+    with pytest.raises(StopAsyncIteration):
+        await pager.next()
+
+    # 测试 collect (页级别)
+    pages = await req.collect(limit=2)
+    assert len(pages) == 2
+
+    # 测试 collect_items (条目级别)
+    items_15 = await req.collect_items(limit=15)
+    assert items_15 == list(range(1, 16))
+
+    all_items = await req.collect_items()
+    assert all_items == list(range(1, 31))
+
+    # 测试未配置 items_extractor 触发 TypeError
+    strategy_no_items = OffsetStrategy[Any, DummyResponse](
+        offset_key="start",
+        page_size=10,
+        total_extractor=lambda r: r.total,
+    )
+    req_no_items = MockPaginatedRequest(
+        _client=cast("Any", None),
+        module="test",
+        method="test",
+        param={"start": 0},
+        pager_strategy=strategy_no_items,
+        responses=[resp1],
+    )
+    with pytest.raises(TypeError, match="未配置 items_extractor"):
+        await req_no_items.collect_items()
+
+
+@pytest.mark.asyncio
+async def test_async_refresher_and_stream():
+    """测试 AsyncRefresher 控制器以及 RefreshableRequest 的 refresh_stream 与 aiter 功能."""
+
+    @dataclass
+    class MockRefreshableRequest(RefreshableRequest):
+        response_map: dict[str, DummyResponse] = field(default_factory=dict)
+
+        def __await__(self):
+            async def _coro():
+                cur = cast("dict[str, Any]", self.param).get("vec", "cur0")
+                return self.response_map.get(cur, DummyResponse(items=[]))
+
+            return _coro().__await__()
+
+    resp1 = DummyResponse(has_more=True, next_cursor="cur1", items=["a", "b"])
+    resp2 = DummyResponse(has_more=True, next_cursor="cur2", items=["c", "d"])
+    resp3 = DummyResponse(has_more=False, next_cursor=None, items=["e", "f"])
+
+    strategy = BatchRefreshStrategy[Any, DummyResponse](
+        refresh_key="vec",
+        cursor_extractor=lambda r: r.next_cursor,
+        has_more_extractor=lambda r: r.has_more,
+        items_extractor=lambda r: r.items,
+    )
+
+    req = MockRefreshableRequest(
+        _client=cast("Any", None),
+        module="test",
+        method="test",
+        param={"vec": "cur0"},
+        refresh_strategy=strategy,
+        response_map={"cur0": resp1, "cur1": resp2, "cur2": resp3},
+    )
+
+    # 测试 refresher 的 first 与 next
+    refresher = req.refresher(limit=2)
+    assert refresher.has_more() is True
+    b1_first = await refresher.first()
+    assert b1_first.items == ["a", "b"]
+    b2 = await refresher.next()
+    assert b2.items == ["c", "d"]
+    b1_again = await refresher.first()
+    assert b1_again.items == ["a", "b"]
+    assert refresher.has_more() is False
+    with pytest.raises(StopAsyncIteration):
+        await refresher.next()
+
+    # 测试 async for batch in req (aiter)
+    batches = [batch async for batch in req]
+    assert len(batches) == 3
+    assert [b.items for b in batches] == [["a", "b"], ["c", "d"], ["e", "f"]]
+
+    # 测试 collect_items
+    items_3 = await req.collect_items(limit=3)
+    assert items_3 == ["a", "b", "c"]

--- a/tests/test_recommend.py
+++ b/tests/test_recommend.py
@@ -7,7 +7,7 @@ from qqmusic_api import Client
 
 async def test_get_home_feed(client: Client) -> None:
     """测试获取主页推荐响应模型."""
-    result = await client.recommend.get_home_feed(page=1, direction=0, s_num=0, v_cache=[])
+    result = await client.recommend.get_home_feed()
     assert result.shelves
     assert result.shelves[0].id > 0
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -76,7 +76,7 @@ async def test_search_by_type_with_int(client: Client) -> None:
 
 
 async def test_search_by_type_paginate(client: Client) -> None:
-    """测试搜索分页支持 next 与 has_more."""
+    """测试按类型搜索按页面迭代 (paginate)."""
     req = client.search.search_by_type("周杰伦", num=5, page=1)
     pages = [page async for page in req.paginate(limit=2)]
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -77,19 +77,13 @@ async def test_search_by_type_with_int(client: Client) -> None:
 
 async def test_search_by_type_paginate(client: Client) -> None:
     """测试搜索分页支持 next 与 has_more."""
-    pager = client.search.search_by_type("周杰伦", num=5, page=1).paginate(limit=2)
+    req = client.search.search_by_type("周杰伦", num=5, page=1)
+    pages = [page async for page in req.paginate(limit=2)]
 
-    assert pager.has_more() is True
-    first_page = await pager.next()
-    assert pager.has_more() is True
-    second_page = await pager.next()
-
-    assert first_page.song
-    assert second_page.song
-    assert first_page.nextpage == 2
-    assert pager.has_more() is False
-    with pytest.raises(StopAsyncIteration):
-        await pager.next()
+    assert len(pages) == 2
+    assert pages[0].song
+    assert pages[1].song
+    assert pages[0].nextpage == 2
 
 
 async def test_search_by_type_with_selectors(client: Client) -> None:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -91,3 +91,10 @@ async def test_search_by_type_with_selectors(client: Client) -> None:
     selectors = [SearchSelector(id=4558, name="默认", type=0)]
     result = await client.search.search_by_type("周杰伦", search_type=SearchType.SONG, num=5, selectors=selectors)
     assert result.song is not None
+
+
+async def test_search_by_type_iter_items(client: Client) -> None:
+    """测试搜索按条目迭代 (iter_items)."""
+    req = client.search.search_by_type("周杰伦", search_type=SearchType.SONG, num=5)
+    songs = [song async for song in req.iter_items(limit=10)]
+    assert len(songs) > 5

--- a/tests/test_song.py
+++ b/tests/test_song.py
@@ -85,9 +85,11 @@ async def test_get_related_mv(client: Client) -> None:
 
 async def test_get_related_songlist_refresh(client: Client) -> None:
     """测试歌曲相关歌单支持换一批."""
-    refresher = client.song.get_related_songlist(100).refresh()
-    first_batch = await refresher.first()
-    next_batch = await refresher.refresh()
+    req1 = client.song.get_related_songlist(100)
+    first_batch = await req1
+    req2 = req1.next_request(first_batch)
+    assert req2 is not None
+    next_batch = await req2
 
     assert first_batch.songlist
     assert next_batch.songlist
@@ -96,9 +98,11 @@ async def test_get_related_songlist_refresh(client: Client) -> None:
 
 async def test_get_related_mv_refresh(client: Client) -> None:
     """测试歌曲相关 MV 支持换一批."""
-    refresher = client.song.get_related_mv(1114857).refresh()
-    first_batch = await refresher.first()
-    next_batch = await refresher.refresh()
+    req1 = client.song.get_related_mv(1114857)
+    first_batch = await req1
+    req2 = req1.next_request(first_batch)
+    assert req2 is not None
+    next_batch = await req2
 
     assert first_batch.mv
     assert next_batch.mv


### PR DESCRIPTION
## 🔗 相关 Issue

Fixes #255

## 💡 变更概述 (Changes Relative to `main`)

本 PR 基于 `main` 主干对 `QQMusicApi` 的分页（Pagination）与换一批（Refresh）系统进行了深度重构与类型安全升级：
移除了原本依赖字符串反射与动态解析的 `PagerMeta` / `RefreshMeta` / `ResponseAdapter` 抽象层，引入全新的**声明式策略模式（Strategy Pattern）**与 **Type State 链式提取器（`.with_extractor()`）**。

---

### 1. 核心架构重构 (`qqmusic_api/core/`) — *与 `main` 对比*

* **移除旧版抽象层**：
  - 彻底废弃 `main` 中的 `ResponseAdapter`、`PagerMeta` 与 `RefreshMeta` 机制。
  - 废弃 `RefreshableRequest`，统一收敛至 `PaginatedRequest` 架构。
* **单泛型策略体系 (`qqmusic_api/core/pagination.py`)**：
  - 将策略模式收敛为单泛型声明 `Strategy[T_Resp_contra]`，使用 `PaginationParams` (`dict[str, Any]`) 统一参数构造契约。
  - 引入 `has_more_extractor`、`total_extractor`、`count_extractor` 与 `cursor_extractor` 等可组合函数提取器。
  - 优化终止判定（`_is_terminated`）：优先尊重 `has_more` 显式标志短路返回，辅以数据计数与总量兜底。
* **Type State 链式组合 (`qqmusic_api/core/request.py`)**：
  - `PaginatedRequest` 提供 `.pager()`、`.paginate()`、`.collect()` 及 `.next_request()` 等无状态/有状态页面控制能力。
  - 引入 `.with_extractor(fn)` 链式构造器：将页面请求升维为 `ItemPaginatedRequest`，提供 `.iter_items()` 与 `.collect_items()` 跨页数据项平铺能力。

---

### 2. 业务 API 模块全量升级 (`qqmusic_api/modules/`) — *与 `main` 对比*

* 全量适配 11 个业务 API 模块（`album`, `comment`, `mv`, `private_message`, `recommend`, `search`, `singer`, `song`, `songlist`, `top`, `user`）：
  - 将 `_build_request` 中的 `pager_meta` / `refresh_meta` 参数更名为 `pager_strategy`。
  - 接入 `.with_extractor(...)` 链式转换，实现条目级解包与迭代。
  - 为所有 API 请求构建函数补充 100% 显式返回类型注解（如 `ItemPaginatedRequest[...]` 或 `Request[...]`）。
* **鲁棒性修复**：
  - **`user.py` (`get_dislike_list`)**：修复 `main` 分支中空列表访问引发 `IndexError` 的隐患，仅在实体列表非空时写入对应的 `*Lastid` 游标。
  - **`recommend.py` (`get_home_feed`)**：维持与 `main` 一致的显式关键字形参，保障 IDE 自动补全体验。

---

### 3. 测试与文档同步 (`tests/` & `docs/`) — *与 `main` 对比*

* **单元测试升级**：
  - 新增 `tests/test_pagination.py` 覆盖策略层边界、终止判定短路与组合模式。
  - 升级业务测试（`test_search.py`、`test_user.py` 等），全面采用 `async for` 的 `paginate()` / `iter_items()` 迭代器语法。
* **开发文档与指南重写**：
  - 同步更新 `docs/coding.md`、`docs/contributing.md` 及 `docs/tutorial/pagination.md`。

---

## ⚠️ Breaking Changes (破坏性变更)

与 `main` 分支相比，本次重构包含以下 BREAKING CHANGES：
1. 移除 `ResponseAdapter`、`PagerMeta`、`RefreshMeta` 及 `RefreshableRequest`。
2. 弃用 `pager.next()` 语法，全面升级为 `async for page in req.paginate()` 或 `async for item in req.iter_items()`。

---

## 🧪 验证结果 (Verification)

- [x] `uv run pytest` 全量测试通过
- [x] `uv run ruff check qqmusic_api tests` 代码规范检查 0 Error
- [x] `uv run pyrefly check` 静态类型检查 0 Error
- [x] `uv run zensical build` 文档站点构建成功
